### PR TITLE
feat: add support for allowing transfer cancellation

### DIFF
--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -31,17 +31,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-expand
-        run: cargo install cargo-expand
+      - name: Install Rust tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand,flutter_rust_bridge_codegen@${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
-
-      - name: Install flutter_rust_bridge_codegen
-        run: cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Get Flutter dependencies
         run: flutter pub get
@@ -95,17 +94,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-expand
-        run: cargo install cargo-expand
+      - name: Install Rust tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand,flutter_rust_bridge_codegen@${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
-
-      - name: Install flutter_rust_bridge_codegen
-        run: cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Get Flutter dependencies
         run: flutter pub get
@@ -142,17 +140,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-expand
-        run: cargo install cargo-expand
+      - name: Install Rust tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand,flutter_rust_bridge_codegen@${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
-
-      - name: Install flutter_rust_bridge_codegen
-        run: cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Get Flutter dependencies
         run: flutter pub get
@@ -201,17 +198,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-expand
-        run: cargo install cargo-expand
+      - name: Install Rust tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand,flutter_rust_bridge_codegen@${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: stable
           cache: true
-
-      - name: Install flutter_rust_bridge_codegen
-        run: cargo install flutter_rust_bridge_codegen --version ${{ env.FLUTTER_RUST_BRIDGE_CODEGEN_VERSION }}
 
       - name: Get Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -36,11 +36,10 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-expand
-        run: cargo install cargo-expand
-
-      - name: Install flutter_rust_bridge_codegen
-        run: cargo install flutter_rust_bridge_codegen --version 2.12.0
+      - name: Install Rust tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-expand,flutter_rust_bridge_codegen@2.12.0
 
       - name: Fetch dependencies
         run: flutter pub get

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 .PHONY: help check test fmt fmt-check clippy server send send-file send-dir send-files send-nearby send-multiple send-large receive demo-receive
 
-SERVER_URL ?= https://drift.samarthv.com
+SERVER_URL ?=
 SERVER_ADDR ?= 0.0.0.0:8787
 FILE ?= Cargo.toml
 DIR ?=
 OUT ?= downloads
 FILES ?= $(FILE)
 TRACE ?= 1
+
+ifneq ($(strip $(SERVER_URL)),)
+RENDEZVOUS_ENV := DRIFT_RENDEZVOUS_URL=$(SERVER_URL)
+endif
 
 ifeq ($(TRACE),0)
 TRACE_ENV := RUST_LOG=off
@@ -47,7 +51,7 @@ help:
 	@echo "Send via LAN (mDNS; receiver must run receive on same network):"
 	@echo "  send-nearby     — generates a fresh $(NEARBY_SIZE_MB)MB random file; NEARBY_TIMEOUT_SECS=$(NEARBY_TIMEOUT_SECS)"
 	@echo ""
-	@echo "Env: SERVER_URL=$(SERVER_URL)"
+	@echo "Env: SERVER_URL=$(if $(SERVER_URL),$(SERVER_URL),<CLI default>)"
 	@echo "     TRACE=$(TRACE) (set TRACE=0 to disable CLI tracing logs)"
 
 check:
@@ -79,16 +83,16 @@ endif
 
 send-file:
 	@if [ -z "$(CODE)" ]; then echo "usage: make send-file CODE=AB2CD3 FILE=path"; exit 1; fi
-	DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$(FILE)"
+	$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$(FILE)"
 
 send-dir:
 	@if [ -z "$(CODE)" ]; then echo "usage: make send-dir CODE=AB2CD3 DIR=photos/"; exit 1; fi
 	@if [ -z "$(DIR)" ]; then echo "usage: make send-dir CODE=AB2CD3 DIR=photos/"; exit 1; fi
-	DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$(DIR)"
+	$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$(DIR)"
 
 send-files:
 	@if [ -z "$(CODE)" ]; then echo "usage: make send-files CODE=AB2CD3 FILES=\"path1 path2\""; exit 1; fi
-	DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" $(FILES)
+	$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" $(FILES)
 
 send-nearby:
 	@set -e; \
@@ -98,7 +102,7 @@ send-nearby:
 		echo "Generating $$NEARBY_FILE ($(NEARBY_SIZE_MB)MB) ..."; \
 		dd if=/dev/urandom of="$$NEARBY_FILE" bs=1m count="$(NEARBY_SIZE_MB)" status=none 2>/dev/null || \
 		dd if=/dev/urandom of="$$NEARBY_FILE" bs=1m count="$(NEARBY_SIZE_MB)" >/dev/null 2>&1; \
-		DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- send --nearby --nearby-timeout-secs $(NEARBY_TIMEOUT_SECS) "$$NEARBY_FILE"
+		$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- send --nearby --nearby-timeout-secs $(NEARBY_TIMEOUT_SECS) "$$NEARBY_FILE"
 
 send-multiple:
 	@if [ -z "$(CODE)" ]; then echo "usage: make send-multiple CODE=AB2CD3"; exit 1; fi
@@ -115,7 +119,7 @@ send-multiple:
 			dd if=/dev/urandom of="$$F" bs=1m count="$(MULTIPLE_SIZE_MB)" >/dev/null 2>&1; \
 			i=$$((i+1)); \
 		done; \
-		DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$$TMD_DIR"
+		$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$$TMD_DIR"
 
 send-large:
 	@if [ -z "$(CODE)" ]; then echo "usage: make send-large CODE=AB2CD3"; exit 1; fi
@@ -126,10 +130,10 @@ send-large:
 		echo "Generating $$LARGE_FILE ($(LARGE_SIZE_MB)MB) ..."; \
 		dd if=/dev/urandom of="$$LARGE_FILE" bs=1m count="$(LARGE_SIZE_MB)" status=none 2>/dev/null || \
 		dd if=/dev/urandom of="$$LARGE_FILE" bs=1m count="$(LARGE_SIZE_MB)" >/dev/null 2>&1; \
-		DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$$LARGE_FILE"
+		$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- send -c "$(CODE)" "$$LARGE_FILE"
 
 receive:
-	DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- receive --out "$(OUT)"
+	$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- receive --out "$(OUT)"
 
 demo-receive:
-	DRIFT_RENDEZVOUS_URL=$(SERVER_URL) $(TRACE_ENV) cargo run -p drift -- receive --out "$(OUT)"
+	$(RENDEZVOUS_ENV) $(TRACE_ENV) cargo run -p drift -- receive --out "$(OUT)"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -7,5 +7,5 @@ pub mod types;
 pub use receiver::{
     OfferDecision, ReceiverEvent, ReceiverLifecycle, ReceiverService, ReceiverSnapshot,
 };
-pub use send::SendSession;
+pub use send::{SendSession, SendSessionOutcome};
 pub use types::*;

--- a/crates/app/src/receiver/actor.rs
+++ b/crates/app/src/receiver/actor.rs
@@ -2,8 +2,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use drift_core::receiver::{
-    ReceiveTransferPhase, ReceiveTransferProgress, receiver_finish_after_decision_with_progress,
-    receiver_run_until_decision,
+    ReceiveTransferOutcome, ReceiveTransferPhase, ReceiveTransferProgress,
+    receiver_finish_after_decision_with_progress, receiver_run_until_decision,
 };
 use drift_core::transfer::{ReceiverMachine, ReceiverState};
 use drift_core::util::human_size;
@@ -44,9 +44,13 @@ pub(super) enum ReceiverCommand {
         decision: OfferDecision,
         reply: oneshot::Sender<Result<()>>,
     },
+    CancelTransfer {
+        reply: oneshot::Sender<Result<()>>,
+    },
     OfferPrepared {
         offer_id: u64,
         decision_tx: oneshot::Sender<OfferResolution>,
+        cancel_tx: watch::Sender<bool>,
         watch_task: JoinHandle<()>,
         event: ReceiverOfferEvent,
     },
@@ -145,8 +149,13 @@ pub(super) async fn run_receiver_actor(
                         let _ = publish_snapshot(&state_tx, &runtime, ReceiverLifecycle::Ready);
                         let _ = reply.send(result);
                     }
-                    ReceiverCommand::OfferPrepared { offer_id, decision_tx, watch_task, event } => {
-                        if runtime.handle_offer_prepared(offer_id, decision_tx, watch_task) {
+                    ReceiverCommand::CancelTransfer { reply } => {
+                        let result = runtime.cancel_active_transfer();
+                        let _ = publish_snapshot(&state_tx, &runtime, ReceiverLifecycle::Ready);
+                        let _ = reply.send(result);
+                    }
+                    ReceiverCommand::OfferPrepared { offer_id, decision_tx, cancel_tx, watch_task, event } => {
+                        if runtime.handle_offer_prepared(offer_id, decision_tx, cancel_tx, watch_task) {
                             let _ = event_tx.send(ReceiverEvent::OfferUpdated(event));
                             let _ = runtime
                                 .refresh_registration_after_offer(&pairing_tx, &event_tx)
@@ -361,6 +370,7 @@ async fn handle_incoming_offer(
         })
         .collect();
     let (decision_tx, decision_rx) = oneshot::channel();
+    let (cancel_tx, cancel_rx) = watch::channel(false);
     let watch_task = spawn_pending_offer_watch_task(
         offer_id,
         pending.connection().clone(),
@@ -391,6 +401,7 @@ async fn handle_incoming_offer(
         .send(ReceiverCommand::OfferPrepared {
             offer_id,
             decision_tx,
+            cancel_tx,
             watch_task,
             event: prepared_event,
         })
@@ -431,25 +442,18 @@ async fn handle_incoming_offer(
         pending,
         &mut machine,
         approved,
+        Some(cancel_rx),
         &mut progress_cb,
     )
     .await
     {
-        Ok(()) => ReceiverOfferEvent {
-            phase: if approved {
-                ReceiverOfferPhase::Completed
-            } else {
-                ReceiverOfferPhase::Declined
-            },
+        Ok(ReceiveTransferOutcome::Completed) => ReceiverOfferEvent {
+            phase: ReceiverOfferPhase::Completed,
             sender_name: String::new(),
             sender_device_type: device_type_to_str(sender_device_type),
             destination_label: sender_label,
             save_root_label,
-            status_message: if approved {
-                "Files saved.".to_owned()
-            } else {
-                "Transfer cancelled.".to_owned()
-            },
+            status_message: "Files saved.".to_owned(),
             item_count: manifest.file_count,
             total_size_bytes: manifest.total_size,
             bytes_received: manifest.total_size,
@@ -457,6 +461,36 @@ async fn handle_incoming_offer(
             total_size_label: human_size(manifest.total_size),
             files: Vec::new(),
             error_message: None,
+        },
+        Ok(ReceiveTransferOutcome::Declined) => ReceiverOfferEvent {
+            phase: ReceiverOfferPhase::Declined,
+            sender_name: String::new(),
+            sender_device_type: device_type_to_str(sender_device_type),
+            destination_label: sender_label,
+            save_root_label,
+            status_message: "Transfer cancelled.".to_owned(),
+            item_count: manifest.file_count,
+            total_size_bytes: manifest.total_size,
+            bytes_received: 0,
+            connection_path: None,
+            total_size_label: human_size(manifest.total_size),
+            files: Vec::new(),
+            error_message: None,
+        },
+        Ok(ReceiveTransferOutcome::Cancelled(cancellation)) => ReceiverOfferEvent {
+            phase: ReceiverOfferPhase::Cancelled,
+            sender_name: String::new(),
+            sender_device_type: device_type_to_str(sender_device_type),
+            destination_label: sender_label,
+            save_root_label,
+            status_message: "Transfer cancelled.".to_owned(),
+            item_count: manifest.file_count,
+            total_size_bytes: manifest.total_size,
+            bytes_received: last_progress_bytes,
+            connection_path: None,
+            total_size_label: human_size(manifest.total_size),
+            files: Vec::new(),
+            error_message: Some(cancellation.reason),
         },
         Err(err) => ReceiverOfferEvent {
             phase: ReceiverOfferPhase::Failed,
@@ -547,6 +581,7 @@ fn map_receiver_offer_progress(
         ReceiveTransferPhase::Receiving => ReceiverOfferPhase::Receiving,
         ReceiveTransferPhase::Completed => ReceiverOfferPhase::Completed,
         ReceiveTransferPhase::Declined => ReceiverOfferPhase::Declined,
+        ReceiveTransferPhase::Cancelled => ReceiverOfferPhase::Cancelled,
         ReceiveTransferPhase::Failed => ReceiverOfferPhase::Failed,
     };
     ReceiverOfferEvent {
@@ -561,6 +596,7 @@ fn map_receiver_offer_progress(
             }
             ReceiveTransferPhase::Completed => "Files saved.".to_owned(),
             ReceiveTransferPhase::Declined => "Transfer cancelled.".to_owned(),
+            ReceiveTransferPhase::Cancelled => "Transfer cancelled.".to_owned(),
             ReceiveTransferPhase::Failed => "Transfer failed.".to_owned(),
         },
         item_count: progress.file_count,

--- a/crates/app/src/receiver/mod.rs
+++ b/crates/app/src/receiver/mod.rs
@@ -172,6 +172,17 @@ impl ReceiverService {
             .context("receiver actor dropped respond_to_offer reply")?
     }
 
+    pub async fn cancel_transfer(&self) -> Result<()> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(ReceiverCommand::CancelTransfer { reply: reply_tx })
+            .await
+            .context("receiver actor stopped before cancel_transfer")?;
+        reply_rx
+            .await
+            .context("receiver actor dropped cancel_transfer reply")?
+    }
+
     pub async fn scan_nearby(&self, timeout_secs: u64) -> Result<Vec<NearbyReceiver>> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx

--- a/crates/app/src/receiver/runtime.rs
+++ b/crates/app/src/receiver/runtime.rs
@@ -34,12 +34,16 @@ pub(super) enum OfferResolution {
 pub(super) enum OfferState {
     Idle,
     Pending(PendingOfferState),
-    Receiving { offer_id: u64 },
+    Receiving {
+        offer_id: u64,
+        cancel_tx: watch::Sender<bool>,
+    },
 }
 
 pub(super) struct PendingOfferState {
     offer_id: u64,
     decision_tx: oneshot::Sender<OfferResolution>,
+    cancel_tx: watch::Sender<bool>,
     watch_task: JoinHandle<()>,
 }
 
@@ -236,7 +240,10 @@ impl ReceiverRuntime {
         pending_offer.watch_task.abort();
         let offer_id = pending_offer.offer_id;
         let resolution = if matches!(decision, OfferDecision::Accept) {
-            self.offer_state = OfferState::Receiving { offer_id };
+            self.offer_state = OfferState::Receiving {
+                offer_id,
+                cancel_tx: pending_offer.cancel_tx.clone(),
+            };
             OfferResolution::Accept
         } else {
             OfferResolution::Decline
@@ -252,6 +259,7 @@ impl ReceiverRuntime {
         &mut self,
         offer_id: u64,
         decision_tx: oneshot::Sender<OfferResolution>,
+        cancel_tx: watch::Sender<bool>,
         watch_task: JoinHandle<()>,
     ) -> bool {
         if !matches!(self.offer_state, OfferState::Idle) {
@@ -263,6 +271,7 @@ impl ReceiverRuntime {
         self.offer_state = OfferState::Pending(PendingOfferState {
             offer_id,
             decision_tx,
+            cancel_tx,
             watch_task,
         });
         true
@@ -272,11 +281,15 @@ impl ReceiverRuntime {
         match &mut self.offer_state {
             OfferState::Pending(pending) if pending.offer_id == offer_id => {
                 pending.watch_task.abort();
-                self.offer_state = OfferState::Receiving { offer_id };
+                self.offer_state = OfferState::Receiving {
+                    offer_id,
+                    cancel_tx: pending.cancel_tx.clone(),
+                };
                 true
             }
             OfferState::Receiving {
                 offer_id: active_offer_id,
+                ..
             } if *active_offer_id == offer_id => true,
             _ => false,
         }
@@ -296,6 +309,7 @@ impl ReceiverRuntime {
             }
             OfferState::Receiving {
                 offer_id: active_offer_id,
+                ..
             } if *active_offer_id == offer_id => {
                 self.offer_state = OfferState::Idle;
                 true
@@ -310,6 +324,16 @@ impl ReceiverRuntime {
 
     pub(super) fn handle_offer_expired(&mut self, offer_id: u64) -> bool {
         self.cancel_pending_offer(offer_id)
+    }
+
+    pub(super) fn cancel_active_transfer(&mut self) -> Result<()> {
+        match &self.offer_state {
+            OfferState::Receiving { cancel_tx, .. } => {
+                let _ = cancel_tx.send(true);
+                Ok(())
+            }
+            _ => Err(anyhow::anyhow!("no active transfer")),
+        }
     }
 
     fn cancel_pending_offer(&mut self, offer_id: u64) -> bool {

--- a/crates/app/src/receiver/tests.rs
+++ b/crates/app/src/receiver/tests.rs
@@ -111,8 +111,9 @@ async fn stale_offer_updates_are_ignored() -> Result<()> {
     let mut runtime = ReceiverRuntime::new(test_config(), endpoint, listener);
 
     let (tx, _rx) = tokio::sync::oneshot::channel::<OfferResolution>();
+    let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
     let watch_task = tokio::spawn(async {});
-    assert!(runtime.handle_offer_prepared(7, tx, watch_task));
+    assert!(runtime.handle_offer_prepared(7, tx, cancel_tx, watch_task));
     assert!(!runtime.handle_offer_progress(8));
     assert!(!runtime.handle_offer_finished(8));
     Ok(())
@@ -128,10 +129,12 @@ async fn busy_runtime_rejects_second_offer() -> Result<()> {
 
     let (tx1, _rx1) = tokio::sync::oneshot::channel::<OfferResolution>();
     let (tx2, rx2) = tokio::sync::oneshot::channel::<OfferResolution>();
+    let (cancel_tx1, _cancel_rx1) = tokio::sync::watch::channel(false);
+    let (cancel_tx2, _cancel_rx2) = tokio::sync::watch::channel(false);
     let watch1 = tokio::spawn(async {});
     let watch2 = tokio::spawn(async {});
-    assert!(runtime.handle_offer_prepared(1, tx1, watch1));
-    assert!(!runtime.handle_offer_prepared(2, tx2, watch2));
+    assert!(runtime.handle_offer_prepared(1, tx1, cancel_tx1, watch1));
+    assert!(!runtime.handle_offer_prepared(2, tx2, cancel_tx2, watch2));
     assert!(matches!(rx2.await.unwrap(), OfferResolution::Decline));
     Ok(())
 }

--- a/crates/app/src/send.rs
+++ b/crates/app/src/send.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
+use tokio::sync::watch;
 
 use crate::error::format_error_chain;
 use crate::types::{
@@ -14,8 +15,8 @@ use drift_core::fs_plan::preview::{
 };
 use drift_core::rendezvous::resolve_server_url;
 use drift_core::sender::{
-    SendTransferPhase as CoreSendTransferPhase, SendTransferProgress, format_code_label,
-    send_files_with_progress, send_files_with_progress_via_lan_ticket,
+    SendTransferPhase as CoreSendTransferPhase, SendTransferProgress, SendTransferResult,
+    format_code_label, send_files_with_progress, send_files_with_progress_via_lan_ticket,
 };
 use drift_core::util::ConnectionPathKind;
 use drift_core::wire::DeviceType;
@@ -24,6 +25,12 @@ use drift_core::wire::DeviceType;
 pub struct SendSession {
     config: SendConfig,
     paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendSessionOutcome {
+    Completed,
+    Cancelled,
 }
 
 impl SendSession {
@@ -109,12 +116,13 @@ impl SendSession {
         &self,
         code: String,
         server_url: Option<String>,
+        cancel_rx: Option<watch::Receiver<bool>>,
         mut on_event: F,
-    ) -> Result<()>
+    ) -> Result<SendSessionOutcome>
     where
         F: FnMut(SendEvent),
     {
-        self.send_to_code_impl(code, server_url, &mut on_event)
+        self.send_to_code_impl(code, server_url, cancel_rx, &mut on_event)
             .await
     }
 
@@ -122,12 +130,13 @@ impl SendSession {
         &self,
         ticket: String,
         destination_label: String,
+        cancel_rx: Option<watch::Receiver<bool>>,
         mut on_event: F,
-    ) -> Result<()>
+    ) -> Result<SendSessionOutcome>
     where
         F: FnMut(SendEvent),
     {
-        self.send_to_nearby_impl(ticket, destination_label, &mut on_event)
+        self.send_to_nearby_impl(ticket, destination_label, cancel_rx, &mut on_event)
             .await
     }
 
@@ -135,8 +144,9 @@ impl SendSession {
         &self,
         code: String,
         server_url: Option<String>,
+        cancel_rx: Option<watch::Receiver<bool>>,
         on_event: &mut F,
-    ) -> Result<()>
+    ) -> Result<SendSessionOutcome>
     where
         F: FnMut(SendEvent),
     {
@@ -149,12 +159,14 @@ impl SendSession {
             Some(normalized_server),
             self.config.device_name.clone(),
             device_type,
+            cancel_rx,
             |progress| on_event(map_progress(progress)),
         )
         .await;
 
         match result {
-            Ok(_) => Ok(()),
+            Ok(SendTransferResult::Completed(_)) => Ok(SendSessionOutcome::Completed),
+            Ok(SendTransferResult::Cancelled(_)) => Ok(SendSessionOutcome::Cancelled),
             Err(error) => {
                 on_event(failed_event(&fallback_destination_label, &error));
                 Err(error)
@@ -166,8 +178,9 @@ impl SendSession {
         &self,
         ticket: String,
         destination_label: String,
+        cancel_rx: Option<watch::Receiver<bool>>,
         on_event: &mut F,
-    ) -> Result<()>
+    ) -> Result<SendSessionOutcome>
     where
         F: FnMut(SendEvent),
     {
@@ -183,12 +196,14 @@ impl SendSession {
             self.paths.clone(),
             self.config.device_name.clone(),
             device_type,
+            cancel_rx,
             |progress| on_event(map_progress(progress)),
         )
         .await;
 
         match result {
-            Ok(_) => Ok(()),
+            Ok(SendTransferResult::Completed(_)) => Ok(SendSessionOutcome::Completed),
+            Ok(SendTransferResult::Cancelled(_)) => Ok(SendSessionOutcome::Cancelled),
             Err(error) => {
                 on_event(failed_event(&fallback_destination_label, &error));
                 Err(error)
@@ -225,6 +240,9 @@ fn map_progress(progress: SendTransferProgress) -> SendEvent {
         ),
         CoreSendTransferPhase::Completed => {
             (SendPhase::Completed, "Files sent successfully".to_owned())
+        }
+        CoreSendTransferPhase::Cancelled => {
+            (SendPhase::Cancelled, "Transfer cancelled.".to_owned())
         }
     };
 

--- a/crates/app/src/types.rs
+++ b/crates/app/src/types.rs
@@ -8,6 +8,7 @@ pub enum SendPhase {
     WaitingForDecision,
     Sending,
     Completed,
+    Cancelled,
     Failed,
 }
 
@@ -56,6 +57,7 @@ pub enum ReceiverOfferPhase {
     OfferReady,
     Receiving,
     Completed,
+    Cancelled,
     Failed,
     Declined,
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -375,7 +375,9 @@ fn render_send_event(
             pb.set_position(event.bytes_sent);
             pb.set_message(event.status_message.clone());
         }
-        SendPhase::Completed | SendPhase::Cancelled | SendPhase::Failed => finish_progress_bar(progress_bar),
+        SendPhase::Completed | SendPhase::Cancelled | SendPhase::Failed => {
+            finish_progress_bar(progress_bar)
+        }
         SendPhase::Connecting | SendPhase::WaitingForDecision => {}
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -6,10 +6,12 @@ use clap::{Args, ValueEnum};
 use drift_app::{
     ConflictPolicy, OfferDecision, ReceiverConfig, ReceiverEvent, ReceiverOfferEvent,
     ReceiverOfferPhase, ReceiverService, SendConfig, SendEvent, SendPhase, SendSession,
+    SendSessionOutcome,
 };
 use drift_core::util::{confirm_accept, human_size, process_display_device_name};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use iroh::SecretKey;
+use tokio::sync::watch;
 use tokio::time::Duration;
 use tracing::{debug, info, warn};
 use tracing_subscriber::EnvFilter;
@@ -94,19 +96,34 @@ pub async fn send(code: String, files: Vec<PathBuf>, server_url: Option<String>)
 
     let mut progress_bar = None;
     let mut last_phase = None;
-    let outcome = session
-        .send_to_code(code, server_url, |event| {
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    let outcome = {
+        let send_future = session.send_to_code(code, server_url, Some(cancel_rx), |event| {
             render_send_event(&mut last_phase, &mut progress_bar, &event)
-        })
-        .await;
+        });
+        tokio::pin!(send_future);
+        let mut cancellation_requested = false;
+        let result = loop {
+            tokio::select! {
+                result = &mut send_future => break result,
+                _ = tokio::signal::ctrl_c(), if !cancellation_requested => {
+                    cancellation_requested = true;
+                    info!("send.cancel_requested");
+                    let _ = cancel_tx.send(true);
+                }
+            }
+        };
+        drop(send_future);
+        result
+    };
     finish_progress_bar(&mut progress_bar);
 
     match &outcome {
-        Ok(()) => info!("send.completed"),
+        Ok(SendSessionOutcome::Completed) => info!("send.completed"),
+        Ok(SendSessionOutcome::Cancelled) => info!("send.cancelled"),
         Err(e) => warn!(error = %e, error_chain = %format!("{e:#}"), "send.failed"),
     }
-
-    outcome
+    outcome.map(|_| ())
 }
 
 pub async fn send_nearby(
@@ -164,21 +181,38 @@ pub async fn send_nearby(
 
     let mut progress_bar = None;
     let mut last_phase = None;
-    let outcome = session
-        .send_to_nearby(
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    let outcome = {
+        let send_future = session.send_to_nearby(
             picked.ticket.clone(),
             format!("Nearby: {}", picked.label),
+            Some(cancel_rx),
             |event| render_send_event(&mut last_phase, &mut progress_bar, &event),
-        )
-        .await;
+        );
+        tokio::pin!(send_future);
+        let mut cancellation_requested = false;
+        let result = loop {
+            tokio::select! {
+                result = &mut send_future => break result,
+                _ = tokio::signal::ctrl_c(), if !cancellation_requested => {
+                    cancellation_requested = true;
+                    info!("send.cancel_requested");
+                    let _ = cancel_tx.send(true);
+                }
+            }
+        };
+        drop(send_future);
+        result
+    };
     finish_progress_bar(&mut progress_bar);
 
     match &outcome {
-        Ok(()) => info!("send.completed"),
+        Ok(SendSessionOutcome::Completed) => info!("send.completed"),
+        Ok(SendSessionOutcome::Cancelled) => info!("send.cancelled"),
         Err(e) => warn!(error = %e, error_chain = %format!("{e:#}"), "send.failed"),
     }
 
-    outcome
+    outcome.map(|_| ())
 }
 
 pub async fn receive(out_dir: PathBuf, server_url: Option<String>) -> Result<()> {
@@ -212,14 +246,29 @@ pub async fn receive(out_dir: PathBuf, server_url: Option<String>) -> Result<()>
     }
 
     let mut event_rx = service.subscribe_events();
+    let mut current_offer_phase = None;
+    let mut cancellation_requested = false;
     let outcome = loop {
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
-                break Ok(());
+                match current_offer_phase {
+                    Some(ReceiverOfferPhase::OfferReady) if !cancellation_requested => {
+                        cancellation_requested = true;
+                        info!("receive.decline_requested");
+                        service.respond_to_offer(OfferDecision::Decline).await?;
+                    }
+                    Some(ReceiverOfferPhase::Receiving) if !cancellation_requested => {
+                        cancellation_requested = true;
+                        info!("receive.cancel_requested");
+                        service.cancel_transfer().await?;
+                    }
+                    _ => break Ok(()),
+                }
             }
             event = event_rx.recv() => {
                 match event {
                     Ok(ReceiverEvent::OfferUpdated(event)) => {
+                        current_offer_phase = Some(event.phase);
                         render_receive_event(&mut last_phase, &mut progress_bar, &event);
                         match event.phase {
                             ReceiverOfferPhase::OfferReady => {
@@ -233,7 +282,9 @@ pub async fn receive(out_dir: PathBuf, server_url: Option<String>) -> Result<()>
                                 };
                                 service.respond_to_offer(decision).await?;
                             }
-                            ReceiverOfferPhase::Completed | ReceiverOfferPhase::Declined => {
+                            ReceiverOfferPhase::Completed
+                            | ReceiverOfferPhase::Declined
+                            | ReceiverOfferPhase::Cancelled => {
                                 break Ok(());
                             }
                             ReceiverOfferPhase::Failed => {
@@ -308,6 +359,9 @@ fn render_send_event(
                     "send.phase"
                 );
             }
+            SendPhase::Cancelled => {
+                info!(phase = "cancelled", receiver = %event.destination_label, "send.phase");
+            }
             SendPhase::Failed => {
                 warn!(phase = "failed", receiver = %event.destination_label, error = ?event.error_message, "send.phase");
             }
@@ -321,7 +375,7 @@ fn render_send_event(
             pb.set_position(event.bytes_sent);
             pb.set_message(event.status_message.clone());
         }
-        SendPhase::Completed | SendPhase::Failed => finish_progress_bar(progress_bar),
+        SendPhase::Completed | SendPhase::Cancelled | SendPhase::Failed => finish_progress_bar(progress_bar),
         SendPhase::Connecting | SendPhase::WaitingForDecision => {}
     }
 }
@@ -361,6 +415,9 @@ fn render_receive_event(
             ReceiverOfferPhase::Declined => {
                 info!(phase = "declined", sender = %event.sender_name, "receive.phase");
             }
+            ReceiverOfferPhase::Cancelled => {
+                info!(phase = "cancelled", sender = %event.sender_name, "receive.phase");
+            }
             ReceiverOfferPhase::Failed => {
                 warn!(phase = "failed", sender = %event.sender_name, error = ?event.error_message, "receive.phase");
             }
@@ -376,6 +433,7 @@ fn render_receive_event(
             pb.set_message(event.status_message.clone());
         }
         ReceiverOfferPhase::Completed
+        | ReceiverOfferPhase::Cancelled
         | ReceiverOfferPhase::Declined
         | ReceiverOfferPhase::Failed => finish_progress_bar(progress_bar),
         ReceiverOfferPhase::OfferReady | ReceiverOfferPhase::Connecting => {}

--- a/crates/core/src/fs_plan/prepare.rs
+++ b/crates/core/src/fs_plan/prepare.rs
@@ -80,7 +80,7 @@ pub async fn prepare_files(paths: Vec<PathBuf>) -> Result<PreparedFiles> {
             }
 
             files.push(PreparedFile {
-                source_path,
+                source_path: absolute_source_path(&source_path)?,
                 transfer_path,
                 size: metadata.len(),
             });
@@ -114,6 +114,16 @@ pub async fn prepare_files(paths: Vec<PathBuf>) -> Result<PreparedFiles> {
             files: manifest_files,
         },
     })
+}
+
+fn absolute_source_path(path: &PathBuf) -> Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.clone());
+    }
+
+    Ok(std::env::current_dir()
+        .context("resolving current directory")?
+        .join(path))
 }
 
 #[cfg(test)]
@@ -156,6 +166,14 @@ mod tests {
 
         let err = prepare_files(vec![file.clone(), file]).await.unwrap_err();
         assert!(err.to_string().contains("duplicate transfer path"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn prepare_files_normalizes_source_paths_for_imports() -> anyhow::Result<()> {
+        let prepared = prepare_files(vec![PathBuf::from("Cargo.toml")]).await?;
+        assert!(prepared.files[0].source_path.is_absolute());
 
         Ok(())
     }

--- a/crates/core/src/receiver.rs
+++ b/crates/core/src/receiver.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, bail};
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use tokio::sync::watch;
 
 use crate::fs_plan::receive::{ExpectedFile, build_expected_files};
 use crate::rendezvous::OfferManifest;
@@ -11,7 +12,9 @@ use crate::session::{
     ExpectedTransferFile, FileReceiveProgress, build_expected_transfer_files,
     receive_files_over_connection_with_progress,
 };
-use crate::transfer::{ReceiverMachine, ReceiverState, ensure_session_id, validate_hello};
+use crate::transfer::{
+    ReceiverMachine, ReceiverState, TransferCancellation, ensure_session_id, validate_hello,
+};
 use crate::util::{ConnectionPathKind, classify_connection_path};
 use crate::wire::{
     Accept, ControlMessage, Decline, DeviceType, Hello, TRANSFER_PROTOCOL_VERSION, TransferRole,
@@ -70,7 +73,15 @@ pub enum ReceiveTransferPhase {
     Receiving,
     Completed,
     Declined,
+    Cancelled,
     Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReceiveTransferOutcome {
+    Completed,
+    Declined,
+    Cancelled(TransferCancellation),
 }
 
 /// High-level receiving metrics suitable for CLI/UI progress rendering.
@@ -177,8 +188,9 @@ pub async fn receiver_finish_after_decision_with_progress<F>(
     mut pending: ReceiverPendingDecision,
     machine: &mut ReceiverMachine,
     approved: bool,
+    cancel_rx: Option<watch::Receiver<bool>>,
     on_progress: &mut F,
-) -> Result<()>
+) -> Result<ReceiveTransferOutcome>
 where
     F: FnMut(ReceiveTransferProgress),
 {
@@ -210,7 +222,7 @@ where
             connection_path_kind,
             error_message: None,
         });
-        return Ok(());
+        return Ok(ReceiveTransferOutcome::Declined);
     }
 
     let session_id = pending.session_id.clone();
@@ -218,18 +230,21 @@ where
     machine.transition(ReceiverState::Approved)?;
     machine.transition(ReceiverState::Receiving)?;
     let expected_files = expected_transfer_files(&pending.manifest, pending.expected_files)?;
-    receive_files_over_connection_with_progress(
+    let mut last_bytes_received = 0_u64;
+    let transfer_result = receive_files_over_connection_with_progress(
         &pending.endpoint,
         &mut pending.control_send,
         &mut pending.control_recv,
         &session_id,
         expected_files,
+        cancel_rx,
         |p: FileReceiveProgress| {
             let current_file_path = if p.file_path.is_empty() {
                 None
             } else {
                 Some(p.file_path.to_string())
             };
+            last_bytes_received = p.total_bytes_received;
             on_progress(ReceiveTransferProgress {
                 phase: ReceiveTransferPhase::Receiving,
                 sender_device_name: sender_device_name.clone(),
@@ -247,6 +262,24 @@ where
         },
     )
     .await?;
+    if let Some(cancellation) = transfer_result {
+        machine.transition(ReceiverState::Cancelled)?;
+        on_progress(ReceiveTransferProgress {
+            phase: ReceiveTransferPhase::Cancelled,
+            sender_device_name,
+            sender_device_type,
+            file_count,
+            total_bytes,
+            bytes_received: last_bytes_received,
+            bytes_to_receive: total_bytes,
+            current_file_path: None,
+            bytes_received_in_file: 0,
+            current_file_size: 0,
+            connection_path_kind,
+            error_message: Some(cancellation.reason.clone()),
+        });
+        return Ok(ReceiveTransferOutcome::Cancelled(cancellation));
+    }
 
     machine.transition(ReceiverState::Completed)?;
     on_progress(ReceiveTransferProgress {
@@ -263,7 +296,7 @@ where
         connection_path_kind,
         error_message: None,
     });
-    Ok(())
+    Ok(ReceiveTransferOutcome::Completed)
 }
 
 /// Send accept/decline and optionally receive payload.
@@ -271,9 +304,9 @@ pub async fn receiver_finish_after_decision(
     pending: ReceiverPendingDecision,
     machine: &mut ReceiverMachine,
     approved: bool,
-) -> Result<()> {
+) -> Result<ReceiveTransferOutcome> {
     let mut noop = |_| {};
-    receiver_finish_after_decision_with_progress(pending, machine, approved, &mut noop).await
+    receiver_finish_after_decision_with_progress(pending, machine, approved, None, &mut noop).await
 }
 
 /// Like [handle_receiver_connection], but also reports receiving progress.
@@ -285,8 +318,9 @@ pub async fn handle_receiver_connection_with_progress<A, F>(
     device_type: DeviceType,
     machine: &mut ReceiverMachine,
     approve: A,
+    cancel_rx: Option<watch::Receiver<bool>>,
     mut on_progress: F,
-) -> Result<()>
+) -> Result<ReceiveTransferOutcome>
 where
     A: Future<Output = Result<bool>>,
     F: FnMut(ReceiveTransferProgress),
@@ -325,7 +359,7 @@ where
     let approved = approve.await?;
 
     let res =
-        receiver_finish_after_decision_with_progress(pending, machine, approved, &mut on_progress)
+        receiver_finish_after_decision_with_progress(pending, machine, approved, cancel_rx, &mut on_progress)
             .await;
 
     if let Err(err) = &res {
@@ -360,7 +394,7 @@ pub async fn handle_receiver_connection<A>(
     device_type: DeviceType,
     machine: &mut ReceiverMachine,
     approve: A,
-) -> Result<()>
+) -> Result<ReceiveTransferOutcome>
 where
     A: Future<Output = Result<bool>>,
 {
@@ -372,6 +406,7 @@ where
         device_type,
         machine,
         approve,
+        None,
         |_| {},
     )
     .await

--- a/crates/core/src/receiver.rs
+++ b/crates/core/src/receiver.rs
@@ -358,9 +358,14 @@ where
 
     let approved = approve.await?;
 
-    let res =
-        receiver_finish_after_decision_with_progress(pending, machine, approved, cancel_rx, &mut on_progress)
-            .await;
+    let res = receiver_finish_after_decision_with_progress(
+        pending,
+        machine,
+        approved,
+        cancel_rx,
+        &mut on_progress,
+    )
+    .await;
 
     if let Err(err) = &res {
         on_progress(ReceiveTransferProgress {

--- a/crates/core/src/sender.rs
+++ b/crates/core/src/sender.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
 use rand::random;
+use tokio::sync::watch;
 
 use crate::fs_plan::prepare::{PreparedFiles, prepare_files};
 use crate::rendezvous::{OfferManifest, RendezvousClient, resolve_server_url, validate_code};
@@ -14,11 +15,13 @@ enum PeerResolution {
     LanTicket(String),
 }
 use crate::session::{bind_endpoint, connect_to_ticket, send_files_over_connection};
-use crate::transfer::{SenderMachine, SenderState, ensure_session_id, validate_hello};
+use crate::transfer::{
+    SenderMachine, SenderState, TransferCancellation, ensure_session_id, validate_hello,
+};
 use crate::util::{ConnectionPathKind, classify_connection_path};
 use crate::wire::{
-    ControlMessage, DeviceType, Hello, Offer, TRANSFER_PROTOCOL_VERSION, TransferRole,
-    decode_ticket, read_message, write_message,
+    CancelPhase, ControlMessage, DeviceType, Hello, Offer, TRANSFER_PROTOCOL_VERSION,
+    TransferRole, decode_ticket, read_message, write_message,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -27,6 +30,7 @@ pub enum SendTransferPhase {
     WaitingForDecision,
     Sending,
     Completed,
+    Cancelled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,14 +58,21 @@ pub struct SendTransferOutcome {
     pub connection_path_kind: ConnectionPathKind,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendTransferResult {
+    Completed(SendTransferOutcome),
+    Cancelled(TransferCancellation),
+}
+
 pub async fn send_files_with_progress<F>(
     code: String,
     files: Vec<PathBuf>,
     server_url: Option<String>,
     device_name: String,
     device_type: DeviceType,
+    cancel_rx: Option<watch::Receiver<bool>>,
     mut on_progress: F,
-) -> Result<SendTransferOutcome>
+) -> Result<SendTransferResult>
 where
     F: FnMut(SendTransferProgress),
 {
@@ -88,6 +99,7 @@ where
         device_type,
         &session_id,
         &prepared,
+        cancel_rx,
         &mut machine,
         &mut on_progress,
     )
@@ -103,8 +115,9 @@ pub async fn send_files_with_progress_via_lan_ticket<F>(
     files: Vec<PathBuf>,
     device_name: String,
     device_type: DeviceType,
+    cancel_rx: Option<watch::Receiver<bool>>,
     mut on_progress: F,
-) -> Result<SendTransferOutcome>
+) -> Result<SendTransferResult>
 where
     F: FnMut(SendTransferProgress),
 {
@@ -129,6 +142,7 @@ where
         device_type,
         &session_id,
         &prepared,
+        cancel_rx,
         &mut machine,
         &mut on_progress,
     )
@@ -141,9 +155,10 @@ async fn send_prepared_files<F>(
     device_type: DeviceType,
     session_id: &str,
     prepared: &PreparedFiles,
+    mut cancel_rx: Option<watch::Receiver<bool>>,
     machine: &mut SenderMachine,
     on_progress: &mut F,
-) -> Result<SendTransferOutcome>
+) -> Result<SendTransferResult>
 where
     F: FnMut(SendTransferProgress),
 {
@@ -164,6 +179,9 @@ where
     let connection = connect_to_ticket(&endpoint, endpoint_addr).await?;
     let connection_path_kind = classify_connection_path(&endpoint, connection.remote_id()).await;
     machine.transition(SenderState::Connected)?;
+    let mut last_bytes_sent = 0_u64;
+    let mut last_file_index = None;
+    let mut last_bytes_sent_in_file = 0_u64;
 
     machine.transition(SenderState::Offering)?;
     let (mut control_send, mut control_recv) = connection
@@ -206,10 +224,57 @@ where
         Some(connection_path_kind),
     ));
 
-    match read_message::<ControlMessage>(&mut control_recv)
-        .await
-        .context("waiting for receiver decision")?
-    {
+    let decision = tokio::select! {
+        cancel_requested = async {
+            let Some(cancel_rx) = cancel_rx.as_mut() else {
+                return false;
+            };
+            if *cancel_rx.borrow() {
+                return true;
+            }
+            loop {
+                if cancel_rx.changed().await.is_err() {
+                    return *cancel_rx.borrow();
+                }
+                if *cancel_rx.borrow() {
+                    return true;
+                }
+            }
+        }, if cancel_rx.is_some() => {
+            if cancel_requested {
+                let cancellation = TransferCancellation {
+                    by: TransferRole::Sender,
+                    phase: CancelPhase::WaitingForDecision,
+                    reason: "sender cancelled before approval".to_owned(),
+                };
+                let _ = send_cancel(
+                    &mut control_send,
+                    session_id,
+                    cancellation.phase,
+                    cancellation.reason.clone(),
+                ).await;
+                machine.transition(SenderState::Cancelled)?;
+                on_progress(progress(
+                    SendTransferPhase::Cancelled,
+                    receiver_hello.device_name.clone(),
+                    prepared,
+                    Some(receiver_hello.device_type),
+                    0,
+                    None,
+                    0,
+                    Some(connection_path_kind),
+                ));
+                endpoint.close().await;
+                return Ok(SendTransferResult::Cancelled(cancellation));
+            }
+            unreachable!()
+        }
+        decision = read_message::<ControlMessage>(&mut control_recv) => {
+            decision.context("waiting for receiver decision")?
+        }
+    };
+
+    match decision {
         ControlMessage::Accept(message) => {
             ensure_session_id(&message.session_id, session_id)?;
             machine.transition(SenderState::Sending)?;
@@ -223,13 +288,17 @@ where
                 0,
                 Some(connection_path_kind),
             ));
-            send_files_over_connection(
+            let session_result = send_files_over_connection(
                 &endpoint,
                 &mut control_send,
                 &mut control_recv,
                 session_id,
                 &prepared.files,
+                cancel_rx.clone(),
                 |p| {
+                    last_bytes_sent = p.total_bytes_sent;
+                    last_file_index = Some(p.file_index as u64);
+                    last_bytes_sent_in_file = p.bytes_sent_in_file;
                     on_progress(progress(
                         SendTransferPhase::Sending,
                         receiver_hello.device_name.clone(),
@@ -243,6 +312,21 @@ where
                 },
             )
             .await?;
+            if let Some(cancellation) = session_result {
+                machine.transition(SenderState::Cancelled)?;
+                on_progress(progress(
+                    SendTransferPhase::Cancelled,
+                    receiver_hello.device_name.clone(),
+                    prepared,
+                    Some(receiver_hello.device_type),
+                    last_bytes_sent,
+                    last_file_index,
+                    last_bytes_sent_in_file,
+                    Some(connection_path_kind),
+                ));
+                endpoint.close().await;
+                return Ok(SendTransferResult::Cancelled(cancellation));
+            }
             machine.transition(SenderState::Completed)?;
             on_progress(progress(
                 SendTransferPhase::Completed,
@@ -261,6 +345,27 @@ where
             endpoint.close().await;
             bail!("receiver declined the offer: {}", message.reason);
         }
+        ControlMessage::Cancel(message) => {
+            ensure_session_id(&message.session_id, session_id)?;
+            let cancellation = TransferCancellation {
+                by: message.by,
+                phase: message.phase,
+                reason: message.reason,
+            };
+            machine.transition(SenderState::Cancelled)?;
+            on_progress(progress(
+                SendTransferPhase::Cancelled,
+                receiver_hello.device_name.clone(),
+                prepared,
+                Some(receiver_hello.device_type),
+                0,
+                None,
+                0,
+                Some(connection_path_kind),
+            ));
+            endpoint.close().await;
+            return Ok(SendTransferResult::Cancelled(cancellation));
+        }
         other => {
             machine.transition(SenderState::Failed)?;
             endpoint.close().await;
@@ -269,11 +374,11 @@ where
     }
 
     endpoint.close().await;
-    Ok(SendTransferOutcome {
+    Ok(SendTransferResult::Completed(SendTransferOutcome {
         receiver_device_name: receiver_hello.device_name,
         manifest: prepared.manifest.clone(),
         connection_path_kind,
-    })
+    }))
 }
 
 fn progress(
@@ -331,6 +436,26 @@ async fn send_offer(
         }),
     )
     .await
+}
+
+async fn send_cancel(
+    send_stream: &mut iroh::endpoint::SendStream,
+    session_id: &str,
+    phase: CancelPhase,
+    reason: String,
+) -> Result<()> {
+    write_message(
+        send_stream,
+        &ControlMessage::Cancel(crate::wire::Cancel {
+            session_id: session_id.to_owned(),
+            by: TransferRole::Sender,
+            phase,
+            reason,
+        }),
+    )
+    .await?;
+    let _ = send_stream.finish();
+    Ok(())
 }
 
 fn make_session_id() -> String {

--- a/crates/core/src/sender.rs
+++ b/crates/core/src/sender.rs
@@ -20,8 +20,8 @@ use crate::transfer::{
 };
 use crate::util::{ConnectionPathKind, classify_connection_path};
 use crate::wire::{
-    CancelPhase, ControlMessage, DeviceType, Hello, Offer, TRANSFER_PROTOCOL_VERSION,
-    TransferRole, decode_ticket, read_message, write_message,
+    CancelPhase, ControlMessage, DeviceType, Hello, Offer, TRANSFER_PROTOCOL_VERSION, TransferRole,
+    decode_ticket, read_message, write_message,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -19,17 +19,18 @@ use iroh_blobs::{
     ticket::BlobTicket,
 };
 use tokio::fs;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio::time::{Duration, timeout};
 use tracing::trace;
 
 use crate::fs_plan::prepare::PreparedFile;
 use crate::fs_plan::receive::{ExpectedFile, build_expected_files};
 use crate::rendezvous::OfferManifest;
+use crate::transfer::TransferCancellation;
 use crate::util::describe_remote;
 use crate::wire::{
-    ALPN, BlobTicketMessage, ControlMessage, TransferAck, TransferErrorCode, TransferResult,
-    TransferStatus, read_message, write_message,
+    ALPN, BlobTicketMessage, Cancel, CancelPhase, ControlMessage, TransferAck,
+    TransferErrorCode, TransferResult, TransferRole, TransferStatus, read_message, write_message,
 };
 
 const CONTROL_STREAM_FINISH_TIMEOUT: Duration = Duration::from_secs(2);
@@ -132,8 +133,9 @@ pub async fn send_files_over_connection<F>(
     control_recv: &mut iroh::endpoint::RecvStream,
     session_id: &str,
     files: &[PreparedFile],
+    mut cancel_rx: Option<watch::Receiver<bool>>,
     mut on_progress: F,
-) -> Result<()>
+) -> Result<Option<TransferCancellation>>
 where
     F: FnMut(FileSendProgress),
 {
@@ -162,6 +164,19 @@ where
                     on_progress(progress);
                 }
             }
+            cancel_requested = wait_for_cancel(&mut cancel_rx), if cancel_rx.is_some() => {
+                if cancel_requested {
+                    let cancellation = local_cancellation(TransferRole::Sender, CancelPhase::Transferring);
+                    let _ = send_cancel(
+                        control_send,
+                        session_id,
+                        cancellation.by,
+                        cancellation.phase,
+                        cancellation.reason.clone(),
+                    ).await;
+                    break Ok(Some(cancellation));
+                }
+            }
             control_message = read_message::<ControlMessage>(control_recv) => {
                 let outcome = match control_message.context("waiting for final transfer result")? {
                     ControlMessage::TransferResult(result) => {
@@ -172,8 +187,11 @@ where
                                 transfer_status_summary(&result.status)
                             ))
                         } else {
-                            Ok(())
+                            Ok(None)
                         }
+                    }
+                    ControlMessage::Cancel(cancel) => {
+                        Ok(Some(cancellation_from_message(cancel, session_id)?))
                     }
                     other => Err(anyhow!("unexpected final control message: {:?}", other)),
                 };
@@ -182,12 +200,13 @@ where
         }
     };
 
-    let ack_result: Result<()> = if result.is_ok() {
+    let ack_result: Result<()> = if matches!(result, Ok(None)) {
         send_transfer_ack(control_send, session_id).await?;
         control_send.finish()?;
         let _ = timeout(CONTROL_STREAM_FINISH_TIMEOUT, control_send.stopped()).await;
         Ok(())
     } else {
+        let _ = control_send.finish();
         Ok(())
     };
 
@@ -195,8 +214,9 @@ where
     // router/store resources on sender-side protocol errors.
     let shutdown_result = provider.shutdown().await;
     shutdown_result?;
-    result?;
-    ack_result
+    let outcome = result?;
+    ack_result?;
+    Ok(outcome)
 }
 
 pub async fn receive_files_over_connection(
@@ -206,7 +226,7 @@ pub async fn receive_files_over_connection(
     session_id: &str,
     out_dir: PathBuf,
     manifest: &OfferManifest,
-) -> Result<()> {
+) -> Result<Option<TransferCancellation>> {
     let expected_files =
         build_expected_transfer_files(manifest, build_expected_files(manifest, &out_dir).await?)?;
     receive_files_over_connection_with_progress(
@@ -215,6 +235,7 @@ pub async fn receive_files_over_connection(
         control_recv,
         session_id,
         expected_files,
+        None,
         |_| {},
     )
     .await
@@ -226,8 +247,9 @@ pub async fn receive_files_over_connection_with_progress<F>(
     control_recv: &mut iroh::endpoint::RecvStream,
     session_id: &str,
     expected_files: Vec<ExpectedTransferFile>,
+    mut cancel_rx: Option<watch::Receiver<bool>>,
     mut on_progress: F,
-) -> Result<()>
+) -> Result<Option<TransferCancellation>>
 where
     F: FnMut(FileReceiveProgress),
 {
@@ -261,42 +283,121 @@ where
         }
     };
 
-    let result = receive_blob_collection(
-        endpoint,
-        &ticket_message.ticket,
-        &expected_files,
-        total_bytes_to_receive,
-        &mut on_progress,
-    )
-    .await;
-    match result {
-        Ok(()) => {
-            send_transfer_result(control_send, session_id, TransferStatus::Ok).await?;
-        }
-        Err(err) => {
-            let status = transfer_error_status(TransferErrorCode::IoError, err.to_string());
-            send_transfer_result(control_send, session_id, status.clone()).await?;
-            return Err(err);
-        }
-    }
-
-    match read_message::<ControlMessage>(control_recv)
+    let blob_ticket: BlobTicket = ticket_message
+        .ticket
+        .parse()
+        .context("parsing blob ticket")?;
+    let download = BlobDownloadStore::new("drift-blobs-recv", session_id).await?;
+    let connection = endpoint
+        .connect(blob_ticket.addr().clone(), BLOBS_ALPN)
         .await
-        .context("waiting for transfer acknowledgement")?
-    {
-        ControlMessage::TransferAck(ack) => {
-            ensure_matching_session_id(&ack.session_id, session_id)?
+        .context("connecting to blob provider")?;
+    let mut stream = download
+        .store
+        .remote()
+        .fetch(connection, blob_ticket.hash_and_format())
+        .stream();
+
+    let result = loop {
+        tokio::select! {
+            cancel_requested = wait_for_cancel(&mut cancel_rx), if cancel_rx.is_some() => {
+                if cancel_requested {
+                    let cancellation = local_cancellation(TransferRole::Receiver, CancelPhase::Transferring);
+                    let _ = send_cancel(
+                        control_send,
+                        session_id,
+                        cancellation.by,
+                        cancellation.phase,
+                        cancellation.reason.clone(),
+                    ).await;
+                    break Ok(Some(cancellation));
+                }
+            }
+            control_message = read_message::<ControlMessage>(control_recv) => {
+                match control_message.context("waiting for transfer control message")? {
+                    ControlMessage::Cancel(cancel) => {
+                        break Ok(Some(cancellation_from_message(cancel, session_id)?));
+                    }
+                    other => {
+                        let status = transfer_error_status(
+                            TransferErrorCode::UnexpectedMessage,
+                            format!(
+                                "unexpected control message while receiving transfer: {:?}",
+                                other
+                            ),
+                        );
+                        send_transfer_result(control_send, session_id, status.clone()).await?;
+                        break Err(anyhow!(transfer_status_summary(&status)));
+                    }
+                }
+            }
+            item = stream.next() => {
+                match item {
+                    Some(GetProgressItem::Progress(offset)) => {
+                        on_progress(FileReceiveProgress {
+                            total_bytes_received: offset,
+                            total_bytes_to_receive,
+                            bytes_received_in_file: 0,
+                            file_size: 0,
+                            file_path: Arc::from(""),
+                        });
+                    }
+                    Some(GetProgressItem::Done(_)) => break Ok(None),
+                    Some(GetProgressItem::Error(err)) => {
+                        let error = anyhow!(err.to_string());
+                        let status = transfer_error_status(TransferErrorCode::IoError, error.to_string());
+                        send_transfer_result(control_send, session_id, status.clone()).await?;
+                        break Err(error);
+                    }
+                    None => break Ok(None),
+                }
+            }
         }
-        other => bail!(
-            "unexpected control message while waiting for transfer acknowledgement: {:?}",
-            other
-        ),
+    };
+
+    let result = match result {
+        Ok(None) => {
+            export_downloaded_collection(&download.store, blob_ticket.hash(), &expected_files).await?;
+            on_progress(FileReceiveProgress {
+                total_bytes_received: total_bytes_to_receive,
+                total_bytes_to_receive,
+                bytes_received_in_file: 0,
+                file_size: 0,
+                file_path: Arc::from(""),
+            });
+            send_transfer_result(control_send, session_id, TransferStatus::Ok).await?;
+            Ok(None)
+        }
+        other => other,
+    };
+
+    drop(stream);
+    let shutdown_result = download.shutdown().await;
+    shutdown_result?;
+    let outcome = result?;
+
+    if outcome.is_none() {
+        match read_message::<ControlMessage>(control_recv)
+            .await
+            .context("waiting for transfer acknowledgement")?
+        {
+            ControlMessage::TransferAck(ack) => {
+                ensure_matching_session_id(&ack.session_id, session_id)?
+            }
+            other => bail!(
+                "unexpected control message while waiting for transfer acknowledgement: {:?}",
+                other
+            ),
+        }
+
+        control_send.finish()?;
+        let _ = timeout(CONTROL_STREAM_FINISH_TIMEOUT, control_send.stopped()).await;
+        println!("Transfer session finished");
+    } else {
+        let _ = control_send.finish();
     }
 
-    control_send.finish()?;
-    let _ = timeout(CONTROL_STREAM_FINISH_TIMEOUT, control_send.stopped()).await;
-    println!("Transfer session finished");
-    Ok(())
+    Ok(outcome)
 }
 
 pub fn build_expected_transfer_files(
@@ -486,66 +587,6 @@ async fn forward_request_updates(
     }
 }
 
-async fn receive_blob_collection<F>(
-    endpoint: &Endpoint,
-    ticket: &str,
-    expected_files: &[ExpectedTransferFile],
-    total_bytes_to_receive: u64,
-    on_progress: &mut F,
-) -> Result<()>
-where
-    F: FnMut(FileReceiveProgress),
-{
-    let blob_ticket: BlobTicket = ticket.parse().context("parsing blob ticket")?;
-    let download = BlobDownloadStore::new("drift-blobs-recv", ticket).await?;
-    // Reuse the receiver's existing endpoint — open a new BLOBS_ALPN connection to the
-    // same peer rather than binding a second local endpoint.
-    let connection = endpoint
-        .connect(blob_ticket.addr().clone(), BLOBS_ALPN)
-        .await
-        .context("connecting to blob provider")?;
-
-    let mut stream = download
-        .store
-        .remote()
-        .fetch(connection, blob_ticket.hash_and_format())
-        .stream();
-
-    let result = async {
-        while let Some(item) = stream.next().await {
-            match item {
-                GetProgressItem::Progress(offset) => {
-                    on_progress(FileReceiveProgress {
-                        total_bytes_received: offset,
-                        total_bytes_to_receive,
-                        bytes_received_in_file: 0,
-                        file_size: 0,
-                        file_path: Arc::from(""),
-                    });
-                }
-                GetProgressItem::Done(_) => break,
-                GetProgressItem::Error(err) => {
-                    return Err(anyhow!(err.to_string()));
-                }
-            }
-        }
-
-        export_downloaded_collection(&download.store, blob_ticket.hash(), expected_files).await?;
-        on_progress(FileReceiveProgress {
-            total_bytes_received: total_bytes_to_receive,
-            total_bytes_to_receive,
-            bytes_received_in_file: 0,
-            file_size: 0,
-            file_path: Arc::from(""),
-        });
-        Ok(())
-    }
-    .await;
-
-    download.shutdown().await?;
-    result
-}
-
 fn make_absolute_path(path: &PathBuf) -> Result<PathBuf> {
     if path.is_absolute() {
         Ok(path.clone())
@@ -619,6 +660,50 @@ fn ensure_matching_session_id(actual: &str, expected: &str) -> Result<()> {
     }
 }
 
+fn local_cancellation(by: TransferRole, phase: CancelPhase) -> TransferCancellation {
+    let reason = match (by, phase) {
+        (TransferRole::Sender, CancelPhase::WaitingForDecision) => {
+            "sender cancelled before approval".to_owned()
+        }
+        (TransferRole::Sender, CancelPhase::Transferring) => "sender cancelled transfer".to_owned(),
+        (TransferRole::Receiver, CancelPhase::WaitingForDecision) => {
+            "receiver cancelled before approval".to_owned()
+        }
+        (TransferRole::Receiver, CancelPhase::Transferring) => {
+            "receiver cancelled transfer".to_owned()
+        }
+    };
+    TransferCancellation { by, phase, reason }
+}
+
+fn cancellation_from_message(cancel: Cancel, session_id: &str) -> Result<TransferCancellation> {
+    ensure_matching_session_id(&cancel.session_id, session_id)?;
+    Ok(TransferCancellation {
+        by: cancel.by,
+        phase: cancel.phase,
+        reason: cancel.reason,
+    })
+}
+
+async fn wait_for_cancel(cancel_rx: &mut Option<watch::Receiver<bool>>) -> bool {
+    let Some(cancel_rx) = cancel_rx.as_mut() else {
+        return false;
+    };
+
+    if *cancel_rx.borrow() {
+        return true;
+    }
+
+    loop {
+        if cancel_rx.changed().await.is_err() {
+            return *cancel_rx.borrow();
+        }
+        if *cancel_rx.borrow() {
+            return true;
+        }
+    }
+}
+
 fn transfer_status_summary(status: &TransferStatus) -> String {
     match status {
         TransferStatus::Ok => "ok".to_owned(),
@@ -628,6 +713,25 @@ fn transfer_status_summary(status: &TransferStatus) -> String {
 
 fn transfer_error_status(code: TransferErrorCode, message: String) -> TransferStatus {
     TransferStatus::Error { code, message }
+}
+
+async fn send_cancel(
+    control_send: &mut iroh::endpoint::SendStream,
+    session_id: &str,
+    by: TransferRole,
+    phase: CancelPhase,
+    reason: String,
+) -> Result<()> {
+    write_message(
+        control_send,
+        &ControlMessage::Cancel(Cancel {
+            session_id: session_id.to_owned(),
+            by,
+            phase,
+            reason,
+        }),
+    )
+    .await
 }
 
 async fn send_transfer_result(

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -29,8 +29,8 @@ use crate::rendezvous::OfferManifest;
 use crate::transfer::TransferCancellation;
 use crate::util::describe_remote;
 use crate::wire::{
-    ALPN, BlobTicketMessage, Cancel, CancelPhase, ControlMessage, TransferAck,
-    TransferErrorCode, TransferResult, TransferRole, TransferStatus, read_message, write_message,
+    ALPN, BlobTicketMessage, Cancel, CancelPhase, ControlMessage, TransferAck, TransferErrorCode,
+    TransferResult, TransferRole, TransferStatus, read_message, write_message,
 };
 
 const CONTROL_STREAM_FINISH_TIMEOUT: Duration = Duration::from_secs(2);
@@ -357,7 +357,8 @@ where
 
     let result = match result {
         Ok(None) => {
-            export_downloaded_collection(&download.store, blob_ticket.hash(), &expected_files).await?;
+            export_downloaded_collection(&download.store, blob_ticket.hash(), &expected_files)
+                .await?;
             on_progress(FileReceiveProgress {
                 total_bytes_received: total_bytes_to_receive,
                 total_bytes_to_receive,

--- a/crates/core/src/transfer.rs
+++ b/crates/core/src/transfer.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 
-use crate::wire::{Hello, TRANSFER_PROTOCOL_VERSION, TransferRole};
+use crate::wire::{CancelPhase, Hello, TRANSFER_PROTOCOL_VERSION, TransferRole};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SenderState {
@@ -13,6 +13,7 @@ pub enum SenderState {
     Sending,
     Completed,
     Declined,
+    Cancelled,
     Failed,
 }
 
@@ -28,7 +29,15 @@ pub enum ReceiverState {
     Receiving,
     Completed,
     Declined,
+    Cancelled,
     Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferCancellation {
+    pub by: TransferRole,
+    pub phase: CancelPhase,
+    pub reason: String,
 }
 
 #[derive(Debug)]
@@ -55,6 +64,8 @@ impl SenderMachine {
                 | (Offering, WaitingForDecision)
                 | (WaitingForDecision, Sending)
                 | (WaitingForDecision, Declined)
+                | (WaitingForDecision, Cancelled)
+                | (Sending, Cancelled)
                 | (Sending, Completed)
                 | (_, Failed)
         );
@@ -99,7 +110,9 @@ impl ReceiverMachine {
                 | (ReviewingOffer, Declined)
                 | (AwaitingDecision, Approved)
                 | (AwaitingDecision, Declined)
+                | (AwaitingDecision, Cancelled)
                 | (Approved, Receiving)
+                | (Receiving, Cancelled)
                 | (Receiving, Completed)
                 | (_, Failed)
         );

--- a/crates/core/src/wire.rs
+++ b/crates/core/src/wire.rs
@@ -45,7 +45,7 @@ pub struct Hello {
     pub device_type: DeviceType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum TransferRole {
     Sender,
@@ -66,6 +66,21 @@ pub struct Accept {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Decline {
     pub session_id: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CancelPhase {
+    WaitingForDecision,
+    Transferring,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Cancel {
+    pub session_id: String,
+    pub by: TransferRole,
+    pub phase: CancelPhase,
     pub reason: String,
 }
 
@@ -114,6 +129,7 @@ pub enum ControlMessage {
     Offer(Offer),
     Accept(Accept),
     Decline(Decline),
+    Cancel(Cancel),
     BlobTicket(BlobTicketMessage),
     TransferResult(TransferResult),
     TransferAck(TransferAck),

--- a/flutter/integration_test/transfer_test.dart
+++ b/flutter/integration_test/transfer_test.dart
@@ -47,6 +47,9 @@ class MockSendTransferSource implements SendTransferSource {
   @override
   Stream<SendTransferUpdate> startTransfer(SendTransferRequestData request) =>
       _controller.stream;
+
+  @override
+  Future<void> cancelTransfer() async {}
 }
 
 class MockNearbyDiscoverySource implements NearbyDiscoverySource {
@@ -77,6 +80,8 @@ class MockReceiverServiceSource implements ReceiverServiceSource {
   Future<void> setDiscoverable({required bool enabled}) async {}
   @override
   Future<void> respondToOffer({required bool accept}) async {}
+  @override
+  Future<void> cancelTransfer() async {}
 }
 
 void main() {

--- a/flutter/lib/platform/send_transfer_source.dart
+++ b/flutter/lib/platform/send_transfer_source.dart
@@ -33,6 +33,7 @@ enum SendTransferUpdatePhase {
   waitingForDecision,
   sending,
   completed,
+  cancelled,
   failed,
 }
 
@@ -64,6 +65,8 @@ class SendTransferUpdate {
 
 abstract class SendTransferSource {
   Stream<SendTransferUpdate> startTransfer(SendTransferRequestData request);
+
+  Future<void> cancelTransfer();
 }
 
 class LocalSendTransferSource implements SendTransferSource {
@@ -101,6 +104,11 @@ class LocalSendTransferSource implements SendTransferSource {
         });
   }
 
+  @override
+  Future<void> cancelTransfer() {
+    return rust_sender.cancelActiveSendTransfer();
+  }
+
   static SendTransferUpdate _mapEvent(rust_sender.SendTransferEvent event) {
     return SendTransferUpdate(
       phase: switch (event.phase) {
@@ -112,6 +120,8 @@ class LocalSendTransferSource implements SendTransferSource {
           SendTransferUpdatePhase.sending,
         rust_sender.SendTransferPhase.completed =>
           SendTransferUpdatePhase.completed,
+        rust_sender.SendTransferPhase.cancelled =>
+          SendTransferUpdatePhase.cancelled,
         rust_sender.SendTransferPhase.failed => SendTransferUpdatePhase.failed,
       },
       destinationLabel: event.destinationLabel,

--- a/flutter/lib/shell/widgets/mobile/mobile_transfer_view.dart
+++ b/flutter/lib/shell/widgets/mobile/mobile_transfer_view.dart
@@ -115,7 +115,7 @@ class MobileTransferView extends ConsumerWidget {
             FilledButton.tonal(
               onPressed: isSending
                   ? notifier.cancelSendInProgress
-                  : notifier.declineReceiveOffer,
+                  : notifier.cancelReceiveInProgress,
               style: FilledButton.styleFrom(
                 foregroundColor: const Color(0xFFCC3333),
                 backgroundColor: const Color(0xFFCC3333).withValues(alpha: 0.1),

--- a/flutter/lib/shell/widgets/receive_receiving_card.dart
+++ b/flutter/lib/shell/widgets/receive_receiving_card.dart
@@ -51,11 +51,15 @@ class ReceiveReceivingCard extends ConsumerWidget {
               onPressed: () => _confirmCancel(context, ref),
               style: TextButton.styleFrom(
                 foregroundColor: const Color(0xFFCC3333),
-                backgroundColor: const Color(0xFFCC3333).withValues(alpha: 0.08),
+                backgroundColor: const Color(
+                  0xFFCC3333,
+                ).withValues(alpha: 0.08),
                 minimumSize: const Size(0, 44),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
-                  side: BorderSide(color: const Color(0xFFCC3333).withValues(alpha: 0.15)),
+                  side: BorderSide(
+                    color: const Color(0xFFCC3333).withValues(alpha: 0.15),
+                  ),
                 ),
               ),
               child: const Text('Cancel'),
@@ -79,7 +83,9 @@ class ReceiveReceivingCard extends ConsumerWidget {
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: const Color(0xFFCC3333)),
+            style: TextButton.styleFrom(
+              foregroundColor: const Color(0xFFCC3333),
+            ),
             child: const Text('Yes, cancel'),
           ),
         ],
@@ -87,7 +93,7 @@ class ReceiveReceivingCard extends ConsumerWidget {
     );
 
     if (confirmed == true) {
-      ref.read(driftAppNotifierProvider.notifier).declineReceiveOffer();
+      ref.read(driftAppNotifierProvider.notifier).cancelReceiveInProgress();
     }
   }
 }

--- a/flutter/lib/src/rust/api/receiver.dart
+++ b/flutter/lib/src/rust/api/receiver.dart
@@ -61,6 +61,9 @@ Stream<ReceiverTransferEvent> startReceiverTransferListener({
 Future<void> respondToReceiverOffer({required bool accept}) =>
     RustLib.instance.api.crateApiReceiverRespondToReceiverOffer(accept: accept);
 
+Future<void> cancelReceiverTransfer() =>
+    RustLib.instance.api.crateApiReceiverCancelReceiverTransfer();
+
 class ReceiverPairingState {
   final String? code;
   final String? expiresAt;
@@ -183,6 +186,7 @@ enum ReceiverTransferPhase {
   offerReady,
   receiving,
   completed,
+  cancelled,
   failed,
   declined,
 }

--- a/flutter/lib/src/rust/api/sender.dart
+++ b/flutter/lib/src/rust/api/sender.dart
@@ -13,6 +13,9 @@ Stream<SendTransferEvent> startSendTransfer({
   required SendTransferRequest request,
 }) => RustLib.instance.api.crateApiSenderStartSendTransfer(request: request);
 
+Future<void> cancelActiveSendTransfer() =>
+    RustLib.instance.api.crateApiSenderCancelActiveSendTransfer();
+
 class SendTransferEvent {
   final SendTransferPhase phase;
   final String destinationLabel;
@@ -65,6 +68,7 @@ enum SendTransferPhase {
   waitingForDecision,
   sending,
   completed,
+  cancelled,
   failed,
 }
 

--- a/flutter/lib/src/rust/frb_generated.dart
+++ b/flutter/lib/src/rust/frb_generated.dart
@@ -71,7 +71,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.12.0';
 
   @override
-  int get rustContentHash => 497836589;
+  int get rustContentHash => 1518490190;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -87,6 +87,10 @@ abstract class RustLibApi extends BaseApi {
     required List<String> existingPaths,
     required List<String> newPaths,
   });
+
+  Future<void> crateApiSenderCancelActiveSendTransfer();
+
+  Future<void> crateApiReceiverCancelReceiverTransfer();
 
   Future<ReceiverRegistration?> crateApiReceiverCurrentReceiverRegistration();
 
@@ -185,7 +189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<ReceiverRegistration?> crateApiReceiverCurrentReceiverRegistration() {
+  Future<void> crateApiSenderCancelActiveSendTransfer() {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
@@ -194,6 +198,63 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             generalizedFrbRustBinding,
             serializer,
             funcId: 2,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSenderCancelActiveSendTransferConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSenderCancelActiveSendTransferConstMeta =>
+      const TaskConstMeta(
+        debugName: "cancel_active_send_transfer",
+        argNames: [],
+      );
+
+  @override
+  Future<void> crateApiReceiverCancelReceiverTransfer() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 3,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiReceiverCancelReceiverTransferConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiReceiverCancelReceiverTransferConstMeta =>
+      const TaskConstMeta(debugName: "cancel_receiver_transfer", argNames: []);
+
+  @override
+  Future<ReceiverRegistration?> crateApiReceiverCurrentReceiverRegistration() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 4,
             port: port_,
           );
         },
@@ -228,7 +289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 5,
             port: port_,
           );
         },
@@ -256,7 +317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 4)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 6)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -281,7 +342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 7,
             port: port_,
           );
         },
@@ -311,7 +372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 8,
             port: port_,
           );
         },
@@ -335,7 +396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -365,7 +426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 10,
             port: port_,
           );
         },
@@ -400,7 +461,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 11,
             port: port_,
           );
         },
@@ -430,7 +491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 12,
             port: port_,
           );
         },
@@ -463,7 +524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 13,
             port: port_,
           );
         },
@@ -496,7 +557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 14,
             port: port_,
           );
         },
@@ -541,7 +602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 13,
+              funcId: 15,
               port: port_,
             );
           },
@@ -585,7 +646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 14,
+              funcId: 16,
               port: port_,
             );
           },
@@ -632,7 +693,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 15,
+              funcId: 17,
               port: port_,
             );
           },

--- a/flutter/lib/state/drift_app_notifier.dart
+++ b/flutter/lib/state/drift_app_notifier.dart
@@ -195,6 +195,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     if (!session.decisionPending) {
       _setSession(
         ReceiveResultSession(
+          success: true,
           items: session.items,
           summary: session.summary.copyWith(
             statusMessage: 'Saved to ${session.summary.destinationLabel}',
@@ -225,10 +226,34 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
   }
 
   void cancelSendInProgress() {
-    if (state.session is! SendTransferSession) {
+    final session = state.session;
+    if (session is! SendTransferSession) {
       return;
     }
-    _returnToSendSelection();
+    _setSession(
+      session.copyWith(
+        phase: SendTransferSessionPhase.cancelling,
+        summary: session.summary.copyWith(
+          statusMessage: 'Cancelling transfer...',
+        ),
+      ),
+    );
+    unawaited(_cancelNativeSendTransfer());
+  }
+
+  void cancelReceiveInProgress() {
+    final session = state.session;
+    if (session is! ReceiveTransferSession) {
+      return;
+    }
+    _setSession(
+      session.copyWith(
+        summary: session.summary.copyWith(
+          statusMessage: 'Cancelling transfer...',
+        ),
+      ),
+    );
+    unawaited(_cancelNativeReceiveTransfer());
   }
 
   void resetShell() {
@@ -505,6 +530,9 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       case rust_receiver.ReceiverTransferPhase.completed:
         _applyIncomingCompleted(event);
         return;
+      case rust_receiver.ReceiverTransferPhase.cancelled:
+        _applyIncomingCancelled(event);
+        return;
       case rust_receiver.ReceiverTransferPhase.failed:
         debugPrint(
           '[drift/notifier] incoming receive failed: '
@@ -598,11 +626,41 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     );
     _setSession(
       ReceiveResultSession(
+        success: true,
         items: state.receiveItems,
         summary: completedSummary,
         metrics: _buildReceiveCompletionMetrics(
           summary: completedSummary,
           bytesReceived: bytesReceived,
+        ),
+        payloadBytesReceived: bytesReceived,
+        payloadTotalBytes: totalBytes,
+        senderDeviceType: event.senderDeviceType,
+      ),
+    );
+  }
+
+  void _applyIncomingCancelled(rust_receiver.ReceiverTransferEvent event) {
+    final bytesReceived = _bigIntToInt(event.bytesReceived);
+    final totalBytes = _bigIntToInt(event.totalSizeBytes);
+    final summary =
+        state.receiveSummary ??
+        TransferSummaryViewData(
+          itemCount: _bigIntToInt(event.itemCount),
+          totalSize: event.totalSizeLabel,
+          code: state.idleReceiveCode,
+          expiresAt: '',
+          destinationLabel: event.saveRootLabel,
+          statusMessage: event.errorMessage ?? event.statusMessage,
+          senderName: event.senderName,
+        );
+    _setSession(
+      ReceiveResultSession(
+        success: false,
+        items: state.receiveItems,
+        summary: summary.copyWith(
+          destinationLabel: event.saveRootLabel,
+          statusMessage: event.errorMessage ?? event.statusMessage,
         ),
         payloadBytesReceived: bytesReceived,
         payloadTotalBytes: totalBytes,
@@ -632,6 +690,26 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       await _receiverServiceSource.respondToOffer(accept: accept);
     } catch (error, stackTrace) {
       debugPrint('respondToOffer failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      resetShell();
+    }
+  }
+
+  Future<void> _cancelNativeSendTransfer() async {
+    try {
+      await _sendTransferSource.cancelTransfer();
+    } catch (error, stackTrace) {
+      debugPrint('cancelTransfer failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      _returnToSendSelection();
+    }
+  }
+
+  Future<void> _cancelNativeReceiveTransfer() async {
+    try {
+      await _receiverServiceSource.cancelTransfer();
+    } catch (error, stackTrace) {
+      debugPrint('cancelReceiveTransfer failed: $error');
       debugPrintStack(stackTrace: stackTrace);
       resetShell();
     }
@@ -858,6 +936,17 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
             remoteDeviceType: update.remoteDeviceType,
           ),
         );
+      case SendTransferUpdatePhase.cancelled:
+        _setSession(
+          SendResultSession(
+            success: false,
+            items: items,
+            summary: summary.copyWith(
+              statusMessage: update.errorMessage ?? 'Transfer cancelled.',
+            ),
+            remoteDeviceType: update.remoteDeviceType,
+          ),
+        );
       case SendTransferUpdatePhase.failed:
         _setSession(
           SendResultSession(
@@ -913,6 +1002,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         );
       case SendTransferUpdatePhase.completed:
       case SendTransferUpdatePhase.failed:
+      case SendTransferUpdatePhase.cancelled:
         _clearSendMetricState();
         return const _SendTransferProgress();
     }

--- a/flutter/lib/state/drift_app_state.dart
+++ b/flutter/lib/state/drift_app_state.dart
@@ -74,6 +74,7 @@ class DriftAppState {
       SendTransferSessionPhase.connecting => TransferStage.ready,
       SendTransferSessionPhase.waitingForDecision ||
       SendTransferSessionPhase.sending => TransferStage.waiting,
+      SendTransferSessionPhase.cancelling => TransferStage.waiting,
     },
     SendResultSession(:final success) =>
       success ? TransferStage.completed : TransferStage.error,
@@ -244,17 +245,23 @@ class DriftAppState {
         tone: success
             ? TransferResultToneData.success
             : TransferResultToneData.error,
-        title: success ? 'Transfer complete' : 'Transfer failed',
+        title: success
+            ? 'Transfer complete'
+            : _isCancelledMessage(summary.statusMessage)
+            ? 'Transfer cancelled'
+            : 'Transfer failed',
         message: summary.statusMessage,
         metrics: success ? metrics : null,
         primaryLabel: success ? 'Done' : null,
       ),
-    ReceiveResultSession(:final summary, :final metrics) =>
+    ReceiveResultSession(:final success, :final summary, :final metrics) =>
       TransferResultViewData(
-        tone: TransferResultToneData.success,
-        title: 'Files saved',
+        tone: success
+            ? TransferResultToneData.success
+            : TransferResultToneData.error,
+        title: success ? 'Files saved' : 'Transfer cancelled',
         message: summary.statusMessage,
-        metrics: metrics,
+        metrics: success ? metrics : null,
         primaryLabel: 'Done',
       ),
     _ => null,
@@ -277,6 +284,9 @@ class DriftAppState {
 
   ShellView get shellView => shellViewFor(this);
 }
+
+bool _isCancelledMessage(String message) =>
+    message.toLowerCase().contains('cancel');
 
 sealed class ShellSessionState {
   const ShellSessionState();
@@ -342,7 +352,12 @@ class SendDraftSession extends ShellSessionState {
   }
 }
 
-enum SendTransferSessionPhase { connecting, waitingForDecision, sending }
+enum SendTransferSessionPhase {
+  connecting,
+  waitingForDecision,
+  sending,
+  cancelling,
+}
 
 class SendTransferSession extends ShellSessionState {
   const SendTransferSession({
@@ -451,6 +466,7 @@ class ReceiveTransferSession extends ShellSessionState {
 
 class ReceiveResultSession extends TransferResultSession {
   const ReceiveResultSession({
+    required this.success,
     required super.items,
     required super.summary,
     super.metrics,
@@ -459,6 +475,7 @@ class ReceiveResultSession extends TransferResultSession {
     this.senderDeviceType,
   }) : super();
 
+  final bool success;
   final int? payloadBytesReceived;
   final int? payloadTotalBytes;
   final String? senderDeviceType;

--- a/flutter/lib/state/receiver_service_source.dart
+++ b/flutter/lib/state/receiver_service_source.dart
@@ -61,6 +61,8 @@ abstract class ReceiverServiceSource {
   Future<void> setDiscoverable({required bool enabled});
 
   Future<void> respondToOffer({required bool accept});
+
+  Future<void> cancelTransfer();
 }
 
 class LocalReceiverServiceSource implements ReceiverServiceSource {
@@ -108,6 +110,11 @@ class LocalReceiverServiceSource implements ReceiverServiceSource {
   @override
   Future<void> respondToOffer({required bool accept}) {
     return rust_receiver.respondToReceiverOffer(accept: accept);
+  }
+
+  @override
+  Future<void> cancelTransfer() {
+    return rust_receiver.cancelReceiverTransfer();
   }
 }
 

--- a/flutter/rust/src/api/receiver.rs
+++ b/flutter/rust/src/api/receiver.rs
@@ -54,6 +54,7 @@ pub enum ReceiverTransferPhase {
     OfferReady,
     Receiving,
     Completed,
+    Cancelled,
     Failed,
     Declined,
 }
@@ -202,6 +203,15 @@ pub fn respond_to_receiver_offer(accept: bool) -> Result<(), String> {
             })
             .await
             .map_err(|e| e.to_string())
+    })
+}
+
+pub fn cancel_receiver_transfer() -> Result<(), String> {
+    RUNTIME.block_on(async move {
+        let Some(service) = current_service() else {
+            return Err("receiver is not running".to_owned());
+        };
+        service.cancel_transfer().await.map_err(|e| e.to_string())
     })
 }
 
@@ -441,6 +451,7 @@ fn map_event(event: AppReceiverOfferEvent) -> ReceiverTransferEvent {
             AppReceiverOfferPhase::OfferReady => ReceiverTransferPhase::OfferReady,
             AppReceiverOfferPhase::Receiving => ReceiverTransferPhase::Receiving,
             AppReceiverOfferPhase::Completed => ReceiverTransferPhase::Completed,
+            AppReceiverOfferPhase::Cancelled => ReceiverTransferPhase::Cancelled,
             AppReceiverOfferPhase::Failed => ReceiverTransferPhase::Failed,
             AppReceiverOfferPhase::Declined => ReceiverTransferPhase::Declined,
         },

--- a/flutter/rust/src/api/sender.rs
+++ b/flutter/rust/src/api/sender.rs
@@ -1,12 +1,19 @@
 use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex};
 
-use drift_app::{SendConfig, SendEvent as AppSendEvent, SendPhase as AppSendPhase, SendSession};
+use drift_app::{
+    SendConfig, SendEvent as AppSendEvent, SendPhase as AppSendPhase, SendSession,
+    SendSessionOutcome,
+};
+use tokio::sync::watch;
 
 use super::RUNTIME;
 use crate::frb_generated::StreamSink;
 
 const LOCAL_RENDEZVOUS_URL: &str = "http://127.0.0.1:8787";
 const ENABLE_DEMO_HELLO_PROTOCOL: bool = false;
+static ACTIVE_SEND_CANCEL: LazyLock<Mutex<Option<watch::Sender<bool>>>> =
+    LazyLock::new(|| Mutex::new(None));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SendTransferPhase {
@@ -14,6 +21,7 @@ pub enum SendTransferPhase {
     WaitingForDecision,
     Sending,
     Completed,
+    Cancelled,
     Failed,
 }
 
@@ -57,9 +65,16 @@ pub fn start_send_transfer(
         },
         request.paths.into_iter().map(PathBuf::from).collect(),
     );
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    if let Ok(mut guard) = ACTIVE_SEND_CANCEL.lock() {
+        if let Some(existing) = guard.replace(cancel_tx.clone()) {
+            let _ = existing.send(true);
+        }
+    }
 
     RUNTIME.block_on(async move {
         let mut emitted_failed_event = false;
+        let mut emitted_cancelled_event = false;
         let result = match request
             .ticket
             .as_deref()
@@ -73,9 +88,13 @@ pub fn start_send_transfer(
                         request
                             .lan_destination_label
                             .unwrap_or_else(|| "Nearby receiver".to_owned()),
+                        Some(cancel_rx.clone()),
                         |event| {
                             if matches!(event.phase, AppSendPhase::Failed) {
                                 emitted_failed_event = true;
+                            }
+                            if matches!(event.phase, AppSendPhase::Cancelled) {
+                                emitted_cancelled_event = true;
                             }
                             let _ = updates.add(map_event(event));
                         },
@@ -87,9 +106,13 @@ pub fn start_send_transfer(
                     .send_to_code(
                         request.code,
                         request.server_url.or(Some(LOCAL_RENDEZVOUS_URL.to_owned())),
+                        Some(cancel_rx),
                         |event| {
                             if matches!(event.phase, AppSendPhase::Failed) {
                                 emitted_failed_event = true;
+                            }
+                            if matches!(event.phase, AppSendPhase::Cancelled) {
+                                emitted_cancelled_event = true;
                             }
                             let _ = updates.add(map_event(event));
                         },
@@ -98,10 +121,14 @@ pub fn start_send_transfer(
             }
         };
 
+        if let Ok(mut guard) = ACTIVE_SEND_CANCEL.lock() {
+            guard.take();
+        }
+
         match result {
-            Ok(()) => Ok(()),
+            Ok(SendSessionOutcome::Completed | SendSessionOutcome::Cancelled) => Ok(()),
             Err(error) => {
-                if !emitted_failed_event {
+                if !emitted_failed_event && !emitted_cancelled_event {
                     let _ = updates.add(SendTransferEvent {
                         phase: SendTransferPhase::Failed,
                         destination_label: fallback_destination,
@@ -117,6 +144,18 @@ pub fn start_send_transfer(
             }
         }
     })
+}
+
+pub fn cancel_active_send_transfer() -> Result<(), String> {
+    let guard = ACTIVE_SEND_CANCEL
+        .lock()
+        .map_err(|_| "send transfer mutex poisoned".to_owned())?;
+    let Some(cancel_tx) = guard.as_ref() else {
+        return Err("no active send transfer".to_owned());
+    };
+    cancel_tx
+        .send(true)
+        .map_err(|_| "send transfer is no longer active".to_owned())
 }
 
 fn fallback_destination_label(request: &SendTransferRequest) -> String {
@@ -148,6 +187,7 @@ fn map_event(event: AppSendEvent) -> SendTransferEvent {
             AppSendPhase::WaitingForDecision => SendTransferPhase::WaitingForDecision,
             AppSendPhase::Sending => SendTransferPhase::Sending,
             AppSendPhase::Completed => SendTransferPhase::Completed,
+            AppSendPhase::Cancelled => SendTransferPhase::Cancelled,
             AppSendPhase::Failed => SendTransferPhase::Failed,
         },
         destination_label: event.destination_label,

--- a/flutter/rust/src/frb_generated.rs
+++ b/flutter/rust/src/frb_generated.rs
@@ -38,7 +38,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.12.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 497836589;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1518490190;
 
 // Section: executor
 
@@ -75,6 +75,70 @@ fn wire__crate__api__preview__append_paths_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok =
                         crate::api::preview::append_paths(api_existing_paths, api_new_paths)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sender__cancel_active_send_transfer_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "cancel_active_send_transfer",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sender::cancel_active_send_transfer()?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__receiver__cancel_receiver_transfer_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "cancel_receiver_transfer",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::receiver::cancel_receiver_transfer()?;
                     Ok(output_ok)
                 })())
             }
@@ -833,8 +897,9 @@ impl SseDecode for crate::api::receiver::ReceiverTransferPhase {
             1 => crate::api::receiver::ReceiverTransferPhase::OfferReady,
             2 => crate::api::receiver::ReceiverTransferPhase::Receiving,
             3 => crate::api::receiver::ReceiverTransferPhase::Completed,
-            4 => crate::api::receiver::ReceiverTransferPhase::Failed,
-            5 => crate::api::receiver::ReceiverTransferPhase::Declined,
+            4 => crate::api::receiver::ReceiverTransferPhase::Cancelled,
+            5 => crate::api::receiver::ReceiverTransferPhase::Failed,
+            6 => crate::api::receiver::ReceiverTransferPhase::Declined,
             _ => unreachable!("Invalid variant for ReceiverTransferPhase: {}", inner),
         };
     }
@@ -905,7 +970,8 @@ impl SseDecode for crate::api::sender::SendTransferPhase {
             1 => crate::api::sender::SendTransferPhase::WaitingForDecision,
             2 => crate::api::sender::SendTransferPhase::Sending,
             3 => crate::api::sender::SendTransferPhase::Completed,
-            4 => crate::api::sender::SendTransferPhase::Failed,
+            4 => crate::api::sender::SendTransferPhase::Cancelled,
+            5 => crate::api::sender::SendTransferPhase::Failed,
             _ => unreachable!("Invalid variant for SendTransferPhase: {}", inner),
         };
     }
@@ -962,43 +1028,55 @@ fn pde_ffi_dispatcher_primary_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__preview__append_paths_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__receiver__current_receiver_registration_impl(
+        2 => wire__crate__api__sender__cancel_active_send_transfer_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        3 => wire__crate__api__receiver__ensure_receiver_registration_impl(
+        3 => wire__crate__api__receiver__cancel_receiver_transfer_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        5 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__preview__inspect_paths_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__receiver__register_receiver_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__preview__remove_path_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__receiver__respond_to_receiver_offer_impl(
+        4 => wire__crate__api__receiver__current_receiver_registration_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__api__lan__scan_nearby_receivers_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__receiver__set_receiver_discoverable_impl(
+        5 => wire__crate__api__receiver__ensure_receiver_registration_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        13 => wire__crate__api__receiver__start_receiver_transfer_listener_impl(
+        7 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__preview__inspect_paths_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__receiver__register_receiver_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__preview__remove_path_impl(port, ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__receiver__respond_to_receiver_offer_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        14 => wire__crate__api__sender__start_send_transfer_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__receiver__watch_receiver_pairing_impl(
+        13 => wire__crate__api__lan__scan_nearby_receivers_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__receiver__set_receiver_discoverable_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        15 => wire__crate__api__receiver__start_receiver_transfer_listener_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        16 => wire__crate__api__sender__start_send_transfer_impl(port, ptr, rust_vec_len, data_len),
+        17 => wire__crate__api__receiver__watch_receiver_pairing_impl(
             port,
             ptr,
             rust_vec_len,
@@ -1016,8 +1094,8 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        4 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__device__random_device_name_impl(ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__device__random_device_name_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1149,8 +1227,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::receiver::ReceiverTransferPha
             Self::OfferReady => 1.into_dart(),
             Self::Receiving => 2.into_dart(),
             Self::Completed => 3.into_dart(),
-            Self::Failed => 4.into_dart(),
-            Self::Declined => 5.into_dart(),
+            Self::Cancelled => 4.into_dart(),
+            Self::Failed => 5.into_dart(),
+            Self::Declined => 6.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -1247,7 +1326,8 @@ impl flutter_rust_bridge::IntoDart for crate::api::sender::SendTransferPhase {
             Self::WaitingForDecision => 1.into_dart(),
             Self::Sending => 2.into_dart(),
             Self::Completed => 3.into_dart(),
-            Self::Failed => 4.into_dart(),
+            Self::Cancelled => 4.into_dart(),
+            Self::Failed => 5.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -1485,8 +1565,9 @@ impl SseEncode for crate::api::receiver::ReceiverTransferPhase {
                 crate::api::receiver::ReceiverTransferPhase::OfferReady => 1,
                 crate::api::receiver::ReceiverTransferPhase::Receiving => 2,
                 crate::api::receiver::ReceiverTransferPhase::Completed => 3,
-                crate::api::receiver::ReceiverTransferPhase::Failed => 4,
-                crate::api::receiver::ReceiverTransferPhase::Declined => 5,
+                crate::api::receiver::ReceiverTransferPhase::Cancelled => 4,
+                crate::api::receiver::ReceiverTransferPhase::Failed => 5,
+                crate::api::receiver::ReceiverTransferPhase::Declined => 6,
                 _ => {
                     unimplemented!("");
                 }
@@ -1539,7 +1620,8 @@ impl SseEncode for crate::api::sender::SendTransferPhase {
                 crate::api::sender::SendTransferPhase::WaitingForDecision => 1,
                 crate::api::sender::SendTransferPhase::Sending => 2,
                 crate::api::sender::SendTransferPhase::Completed => 3,
-                crate::api::sender::SendTransferPhase::Failed => 4,
+                crate::api::sender::SendTransferPhase::Cancelled => 4,
+                crate::api::sender::SendTransferPhase::Failed => 5,
                 _ => {
                     unimplemented!("");
                 }

--- a/flutter/test/state/drift_app_notifier_test.dart
+++ b/flutter/test/state/drift_app_notifier_test.dart
@@ -184,6 +184,9 @@ class FakeSendTransferSource implements SendTransferSource {
     return controller.stream;
   }
 
+  @override
+  Future<void> cancelTransfer() async {}
+
   Future<void> dispose() async {
     await controller.close();
   }
@@ -226,6 +229,9 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
   Future<void> respondToOffer({required bool accept}) async {
     respondToOfferCalls.add(accept);
   }
+
+  @override
+  Future<void> cancelTransfer() async {}
 
   @override
   Future<void> setDiscoverable({required bool enabled}) async {

--- a/flutter/test/widget_test.dart
+++ b/flutter/test/widget_test.dart
@@ -296,6 +296,19 @@ class FakeSendTransferSource implements SendTransferSource {
     return _controller!.stream;
   }
 
+  @override
+  Future<void> cancelTransfer() async {
+    _controller?.add(
+      sendTransferUpdate(
+        phase: SendTransferUpdatePhase.cancelled,
+        destinationLabel: lastRequest?.code.isNotEmpty == true
+            ? 'Code AB2 CD3'
+            : (lastRequest?.lanDestinationLabel ?? 'Nearby receiver'),
+        statusMessage: 'Transfer cancelled.',
+      ),
+    );
+  }
+
   void emit(SendTransferUpdate update) {
     _controller?.add(update);
   }
@@ -322,6 +335,9 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
       StreamController<rust_receiver.ReceiverTransferEvent>.broadcast();
   final List<bool> discoverableCalls = <bool>[];
   final List<bool> respondToOfferCalls = <bool>[];
+
+  @override
+  Future<void> cancelTransfer() async {}
 
   void emitBadge(ReceiverBadgeState badge) {
     _badgeController.add(badge);
@@ -689,9 +705,7 @@ void main() {
     expectNoFlutterError(tester);
   });
 
-  testWidgets('valid send code starts only after tapping Send', (
-    tester,
-  ) async {
+  testWidgets('valid send code starts only after tapping Send', (tester) async {
     final sendTransferSource = FakeSendTransferSource();
     await pumpUtilityApp(
       tester,
@@ -763,7 +777,7 @@ void main() {
     expectNoFlutterError(tester);
   });
 
-  testWidgets('cancel during send returns to file selection', (tester) async {
+  testWidgets('cancel during send shows a cancelled result', (tester) async {
     final sendTransferSource = FakeSendTransferSource();
     final container = buildTestContainer(
       sendTransferSource: sendTransferSource,
@@ -794,56 +808,57 @@ void main() {
     await tester.tap(find.text('Yes, cancel'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Send with code'), findsOneWidget);
-    expect(find.text('sample.txt'), findsWidgets);
+    expect(find.text('Transfer cancelled'), findsOneWidget);
+    expect(find.text('Transfer cancelled.'), findsOneWidget);
     container.read(driftAppNotifierProvider.notifier).resetShell();
     await tester.pumpAndSettle();
     expectNoFlutterError(tester);
   });
 
-  testWidgets('nearby device selection starts send with LAN ticket after Send', (
-    tester,
-  ) async {
-    final sendTransferSource = FakeSendTransferSource();
-    Future<List<SendDestinationViewData>> fakeScan() async => [
-      const SendDestinationViewData(
-        name: 'Lab Mac',
-        kind: SendDestinationKind.laptop,
-        lanTicket: 'ticket-abc',
-        lanFullname: 'recv-abc123xyz0._drift._udp.local.',
-      ),
-    ];
+  testWidgets(
+    'nearby device selection starts send with LAN ticket after Send',
+    (tester) async {
+      final sendTransferSource = FakeSendTransferSource();
+      Future<List<SendDestinationViewData>> fakeScan() async => [
+        const SendDestinationViewData(
+          name: 'Lab Mac',
+          kind: SendDestinationKind.laptop,
+          lanTicket: 'ticket-abc',
+          lanFullname: 'recv-abc123xyz0._drift._udp.local.',
+        ),
+      ];
 
-    await pumpUtilityApp(
-      tester,
-      container: buildTestContainer(
-        sendTransferSource: sendTransferSource,
-        nearbySendScan: fakeScan,
-      ),
-    );
+      await pumpUtilityApp(
+        tester,
+        container: buildTestContainer(
+          sendTransferSource: sendTransferSource,
+          nearbySendScan: fakeScan,
+        ),
+      );
 
-    await tester.tap(chooseFilesButton());
-    await tester.pumpAndSettle();
+      await tester.tap(chooseFilesButton());
+      await tester.pumpAndSettle();
 
-    expect(find.text('Nearby devices'), findsOneWidget);
-    expect(find.text('Lab Mac'), findsOneWidget);
+      expect(find.text('Nearby devices'), findsOneWidget);
+      expect(find.text('Lab Mac'), findsOneWidget);
 
-    await tester.ensureVisible(find.text('Lab Mac'));
-    await tester.tap(find.text('Lab Mac'));
-    await tester.pump();
+      await tester.ensureVisible(find.text('Lab Mac'));
+      await tester.tap(find.text('Lab Mac'));
+      await tester.pump();
 
-    expect(sendTransferSource.lastRequest, isNull);
+      expect(sendTransferSource.lastRequest, isNull);
 
-    await tester.tap(find.text('Send'));
-    await tester.pump();
+      await tester.tap(find.text('Send'));
+      await tester.pump();
 
-    expect(sendTransferSource.lastRequest, isNotNull);
-    expect(sendTransferSource.lastRequest?.ticket, 'ticket-abc');
-    expect(sendTransferSource.lastRequest?.lanDestinationLabel, 'Lab Mac');
-    expect(sendTransferSource.lastRequest?.code, '');
-    expect(sendTransferSource.lastRequest?.paths, ['sample.txt', 'photos/']);
-    expectNoFlutterError(tester);
-  });
+      expect(sendTransferSource.lastRequest, isNotNull);
+      expect(sendTransferSource.lastRequest?.ticket, 'ticket-abc');
+      expect(sendTransferSource.lastRequest?.lanDestinationLabel, 'Lab Mac');
+      expect(sendTransferSource.lastRequest?.code, '');
+      expect(sendTransferSource.lastRequest?.paths, ['sample.txt', 'photos/']);
+      expectNoFlutterError(tester);
+    },
+  );
 
   testWidgets('partial send code does not begin the transfer', (tester) async {
     final sendTransferSource = FakeSendTransferSource();


### PR DESCRIPTION
This PR introduces the ability to cancel transfers across the entire stack (Core, App, CLI, and Flutter). It also includes a fix for path normalization when preparing files from relative paths.