### PR TITLE
feat: add transfer progress metrics

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -562,7 +562,8 @@ fn build_transfer_progress_message(
     bytes_transferred: u64,
     total_size: u64,
 ) -> String {
-    let Some(bps) = smoothed_bps.filter(|bps| *bps >= TransferProgressMetrics::MIN_VISIBLE_BPS) else {
+    let Some(bps) = smoothed_bps.filter(|bps| *bps >= TransferProgressMetrics::MIN_VISIBLE_BPS)
+    else {
         return status_message.to_owned();
     };
 
@@ -690,8 +691,12 @@ mod tests {
         assert_eq!(third, "Sending to Receiver. 320.0 KB/s");
 
         metrics.reset();
-        let completed_message =
-            metrics.message_for("Files sent successfully", 4_000, 4_000, start + Duration::from_millis(300));
+        let completed_message = metrics.message_for(
+            "Files sent successfully",
+            4_000,
+            4_000,
+            start + Duration::from_millis(300),
+        );
         assert_eq!(completed_message, "Files sent successfully");
 
         let restarted = metrics.message_for(
@@ -705,7 +710,8 @@ mod tests {
 
     #[test]
     fn build_message_omits_eta_when_transfer_is_complete() {
-        let message = build_transfer_progress_message("Sending to Receiver.", Some(2_048.0), 10, 10);
+        let message =
+            build_transfer_progress_message("Sending to Receiver.", Some(2_048.0), 10, 10);
         assert_eq!(message, "Sending to Receiver. 2.0 KB/s");
     }
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -96,10 +96,11 @@ pub async fn send(code: String, files: Vec<PathBuf>, server_url: Option<String>)
 
     let mut progress_bar = None;
     let mut last_phase = None;
+    let mut metrics = SendProgressMetrics::default();
     let (cancel_tx, cancel_rx) = watch::channel(false);
     let outcome = {
         let send_future = session.send_to_code(code, server_url, Some(cancel_rx), |event| {
-            render_send_event(&mut last_phase, &mut progress_bar, &event)
+            render_send_event(&mut last_phase, &mut progress_bar, &mut metrics, &event)
         });
         tokio::pin!(send_future);
         let mut cancellation_requested = false;
@@ -181,13 +182,14 @@ pub async fn send_nearby(
 
     let mut progress_bar = None;
     let mut last_phase = None;
+    let mut metrics = SendProgressMetrics::default();
     let (cancel_tx, cancel_rx) = watch::channel(false);
     let outcome = {
         let send_future = session.send_to_nearby(
             picked.ticket.clone(),
             format!("Nearby: {}", picked.label),
             Some(cancel_rx),
-            |event| render_send_event(&mut last_phase, &mut progress_bar, &event),
+            |event| render_send_event(&mut last_phase, &mut progress_bar, &mut metrics, &event),
         );
         tokio::pin!(send_future);
         let mut cancellation_requested = false;
@@ -336,6 +338,7 @@ pub async fn receive(out_dir: PathBuf, conflict: String, server_url: Option<Stri
 fn render_send_event(
     last_phase: &mut Option<SendPhase>,
     progress_bar: &mut Option<ProgressBar>,
+    metrics: &mut SendProgressMetrics,
     event: &SendEvent,
 ) {
     if last_phase.as_ref() != Some(&event.phase) {
@@ -380,12 +383,17 @@ fn render_send_event(
         SendPhase::Sending => {
             let pb = ensure_progress_bar(progress_bar, event.total_size);
             pb.set_position(event.bytes_sent);
-            pb.set_message(event.status_message.clone());
+            let now = std::time::Instant::now();
+            let message = metrics.message_for(event, now);
+            pb.set_message(message);
         }
         SendPhase::Completed | SendPhase::Cancelled | SendPhase::Failed => {
+            metrics.reset();
             finish_progress_bar(progress_bar)
         }
-        SendPhase::Connecting | SendPhase::WaitingForDecision => {}
+        SendPhase::Connecting | SendPhase::WaitingForDecision => {
+            metrics.reset();
+        }
     }
 }
 
@@ -472,5 +480,226 @@ fn ensure_progress_bar(progress_bar: &mut Option<ProgressBar>, total: u64) -> &P
 fn finish_progress_bar(progress_bar: &mut Option<ProgressBar>) {
     if let Some(pb) = progress_bar.take() {
         pb.finish_and_clear();
+    }
+}
+
+#[derive(Debug, Default)]
+struct SendProgressMetrics {
+    sample_started_at: Option<std::time::Instant>,
+    sample_started_bytes: Option<u64>,
+    smoothed_bps: Option<f64>,
+}
+
+impl SendProgressMetrics {
+    const MIN_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(80);
+    const MIN_VISIBLE_BPS: f64 = 16.0;
+    const EWMA_ALPHA: f64 = 0.22;
+
+    fn reset(&mut self) {
+        self.sample_started_at = None;
+        self.sample_started_bytes = None;
+        self.smoothed_bps = None;
+    }
+
+    fn message_for(&mut self, event: &SendEvent, now: std::time::Instant) -> String {
+        if event.phase != SendPhase::Sending {
+            self.reset();
+            return event.status_message.clone();
+        }
+
+        let prev_at = self.sample_started_at;
+        let prev_bytes = self.sample_started_bytes;
+        if let (Some(prev_at), Some(prev_bytes)) = (prev_at, prev_bytes) {
+            let dt = now.saturating_duration_since(prev_at);
+            let d_bytes = event.bytes_sent.saturating_sub(prev_bytes);
+            if dt >= Self::MIN_SAMPLE_INTERVAL && d_bytes > 0 {
+                let inst_bps = d_bytes as f64 / dt.as_secs_f64();
+                self.smoothed_bps = Some(match self.smoothed_bps {
+                    Some(prev) => Self::EWMA_ALPHA * inst_bps + (1.0 - Self::EWMA_ALPHA) * prev,
+                    None => inst_bps,
+                });
+                self.sample_started_at = Some(now);
+                self.sample_started_bytes = Some(event.bytes_sent);
+            }
+        } else {
+            self.sample_started_at = Some(now);
+            self.sample_started_bytes = Some(event.bytes_sent);
+        }
+
+        build_send_progress_message(
+            &event.status_message,
+            self.smoothed_bps,
+            event.bytes_sent,
+            event.total_size,
+        )
+    }
+}
+
+fn build_send_progress_message(
+    status_message: &str,
+    smoothed_bps: Option<f64>,
+    bytes_sent: u64,
+    total_size: u64,
+) -> String {
+    let Some(bps) = smoothed_bps.filter(|bps| *bps >= SendProgressMetrics::MIN_VISIBLE_BPS) else {
+        return status_message.to_owned();
+    };
+
+    let speed = format_bytes_per_second(bps);
+    let remaining = total_size.saturating_sub(bytes_sent);
+    let eta = if remaining == 0 {
+        None
+    } else {
+        Some(format_eta_seconds(remaining as f64 / bps))
+    };
+
+    match eta {
+        Some(eta) => format!("{status_message} {speed}, ETA {eta}"),
+        None => format!("{status_message} {speed}"),
+    }
+}
+
+fn format_bytes_per_second(bytes_per_second: f64) -> String {
+    let rounded = bytes_per_second.max(0.0).round();
+    format!("{}/s", human_size(rounded as u64))
+}
+
+fn format_eta_seconds(seconds: f64) -> String {
+    let total_seconds = seconds.max(0.0).round() as u64;
+    let hours = total_seconds / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let secs = total_seconds % 60;
+
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{secs:02}")
+    } else {
+        format!("{minutes:02}:{secs:02}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        SendProgressMetrics, build_send_progress_message, format_bytes_per_second,
+        format_eta_seconds,
+    };
+    use drift_app::{SendEvent, SendPhase};
+    use std::time::{Duration, Instant};
+
+    fn sending_event(bytes_sent: u64, total_size: u64) -> SendEvent {
+        SendEvent {
+            phase: SendPhase::Sending,
+            destination_label: "Receiver".to_owned(),
+            status_message: "Sending to Receiver.".to_owned(),
+            item_count: 1,
+            total_size,
+            bytes_sent,
+            remote_device_type: None,
+            connection_path: None,
+            error_message: None,
+        }
+    }
+
+    #[test]
+    fn metrics_hide_speed_until_sample_window_is_large_enough() {
+        let mut metrics = SendProgressMetrics::default();
+        let start = Instant::now();
+
+        let initial = metrics.message_for(&sending_event(0, 2_000), start);
+        let early = metrics.message_for(
+            &sending_event(500, 2_000),
+            start + Duration::from_millis(40),
+        );
+
+        assert_eq!(initial, "Sending to Receiver.");
+        assert_eq!(early, "Sending to Receiver.");
+    }
+
+    #[test]
+    fn metrics_show_speed_and_eta_after_valid_progress_samples() {
+        let mut metrics = SendProgressMetrics::default();
+        let start = Instant::now();
+
+        let first = metrics.message_for(&sending_event(0, 2_000), start);
+        let second = metrics.message_for(
+            &sending_event(1_000, 2_000),
+            start + Duration::from_millis(100),
+        );
+
+        assert_eq!(first, "Sending to Receiver.");
+        assert_eq!(second, "Sending to Receiver. 9.8 KB/s, ETA 00:00");
+    }
+
+    #[test]
+    fn metrics_accumulate_across_fast_callbacks_until_sample_window_opens() {
+        let mut metrics = SendProgressMetrics::default();
+        let start = Instant::now();
+
+        let _ = metrics.message_for(&sending_event(0, 50_000), start);
+        let _ = metrics.message_for(
+            &sending_event(16_384, 50_000),
+            start + Duration::from_millis(20),
+        );
+        let _ = metrics.message_for(
+            &sending_event(32_768, 50_000),
+            start + Duration::from_millis(40),
+        );
+        let final_message = metrics.message_for(
+            &sending_event(49_152, 50_000),
+            start + Duration::from_millis(100),
+        );
+
+        assert_eq!(final_message, "Sending to Receiver. 480.0 KB/s, ETA 00:00");
+    }
+
+    #[test]
+    fn metrics_apply_ewma_and_reset_outside_sending_phase() {
+        let mut metrics = SendProgressMetrics::default();
+        let start = Instant::now();
+
+        let _ = metrics.message_for(&sending_event(0, 4_000), start);
+        let _ = metrics.message_for(
+            &sending_event(1_000, 4_000),
+            start + Duration::from_millis(100),
+        );
+        let third = metrics.message_for(
+            &sending_event(2_000, 4_000),
+            start + Duration::from_millis(200),
+        );
+
+        assert_eq!(third, "Sending to Receiver. 9.8 KB/s, ETA 00:00");
+
+        let completed = SendEvent {
+            phase: SendPhase::Completed,
+            destination_label: "Receiver".to_owned(),
+            status_message: "Files sent successfully".to_owned(),
+            item_count: 1,
+            total_size: 4_000,
+            bytes_sent: 4_000,
+            remote_device_type: None,
+            connection_path: None,
+            error_message: None,
+        };
+        let completed_message = metrics.message_for(&completed, start + Duration::from_millis(300));
+        assert_eq!(completed_message, "Files sent successfully");
+
+        let restarted = metrics.message_for(
+            &sending_event(500, 4_000),
+            start + Duration::from_millis(400),
+        );
+        assert_eq!(restarted, "Sending to Receiver.");
+    }
+
+    #[test]
+    fn build_message_omits_eta_when_transfer_is_complete() {
+        let message = build_send_progress_message("Sending to Receiver.", Some(2_048.0), 10, 10);
+        assert_eq!(message, "Sending to Receiver. 2.0 KB/s");
+    }
+
+    #[test]
+    fn formatting_helpers_match_cli_output_expectations() {
+        assert_eq!(format_bytes_per_second(1_536.0), "1.5 KB/s");
+        assert_eq!(format_eta_seconds(5.0), "00:05");
+        assert_eq!(format_eta_seconds(3_725.0), "1:02:05");
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -96,7 +96,7 @@ pub async fn send(code: String, files: Vec<PathBuf>, server_url: Option<String>)
 
     let mut progress_bar = None;
     let mut last_phase = None;
-    let mut metrics = SendProgressMetrics::default();
+    let mut metrics = TransferProgressMetrics::default();
     let (cancel_tx, cancel_rx) = watch::channel(false);
     let outcome = {
         let send_future = session.send_to_code(code, server_url, Some(cancel_rx), |event| {
@@ -182,7 +182,7 @@ pub async fn send_nearby(
 
     let mut progress_bar = None;
     let mut last_phase = None;
-    let mut metrics = SendProgressMetrics::default();
+    let mut metrics = TransferProgressMetrics::default();
     let (cancel_tx, cancel_rx) = watch::channel(false);
     let outcome = {
         let send_future = session.send_to_nearby(
@@ -235,6 +235,7 @@ pub async fn receive(out_dir: PathBuf, conflict: String, server_url: Option<Stri
 
     let mut progress_bar = None;
     let mut last_phase = None;
+    let mut metrics = TransferProgressMetrics::default();
     let service = ReceiverService::start(ReceiverConfig {
         device_name,
         device_type: "laptop".to_owned(),
@@ -278,7 +279,7 @@ pub async fn receive(out_dir: PathBuf, conflict: String, server_url: Option<Stri
                 match event {
                     Ok(ReceiverEvent::OfferUpdated(event)) => {
                         current_offer_phase = Some(event.phase);
-                        render_receive_event(&mut last_phase, &mut progress_bar, &event);
+                        render_receive_event(&mut last_phase, &mut progress_bar, &mut metrics, &event);
                         match event.phase {
                             ReceiverOfferPhase::OfferReady => {
                                 let accept = tokio::task::spawn_blocking(confirm_accept)
@@ -338,7 +339,7 @@ pub async fn receive(out_dir: PathBuf, conflict: String, server_url: Option<Stri
 fn render_send_event(
     last_phase: &mut Option<SendPhase>,
     progress_bar: &mut Option<ProgressBar>,
-    metrics: &mut SendProgressMetrics,
+    metrics: &mut TransferProgressMetrics,
     event: &SendEvent,
 ) {
     if last_phase.as_ref() != Some(&event.phase) {
@@ -384,7 +385,12 @@ fn render_send_event(
             let pb = ensure_progress_bar(progress_bar, event.total_size);
             pb.set_position(event.bytes_sent);
             let now = std::time::Instant::now();
-            let message = metrics.message_for(event, now);
+            let message = metrics.message_for(
+                event.status_message.as_str(),
+                event.bytes_sent,
+                event.total_size,
+                now,
+            );
             pb.set_message(message);
         }
         SendPhase::Completed | SendPhase::Cancelled | SendPhase::Failed => {
@@ -400,6 +406,7 @@ fn render_send_event(
 fn render_receive_event(
     last_phase: &mut Option<ReceiverOfferPhase>,
     progress_bar: &mut Option<ProgressBar>,
+    metrics: &mut TransferProgressMetrics,
     event: &ReceiverOfferEvent,
 ) {
     if last_phase.as_ref() != Some(&event.phase) {
@@ -447,13 +454,25 @@ fn render_receive_event(
         ReceiverOfferPhase::Receiving => {
             let pb = ensure_progress_bar(progress_bar, event.total_size_bytes.max(1));
             pb.set_position(event.bytes_received.min(event.total_size_bytes));
-            pb.set_message(event.status_message.clone());
+            let now = std::time::Instant::now();
+            let message = metrics.message_for(
+                event.status_message.as_str(),
+                event.bytes_received,
+                event.total_size_bytes,
+                now,
+            );
+            pb.set_message(message);
         }
         ReceiverOfferPhase::Completed
         | ReceiverOfferPhase::Cancelled
         | ReceiverOfferPhase::Declined
-        | ReceiverOfferPhase::Failed => finish_progress_bar(progress_bar),
-        ReceiverOfferPhase::OfferReady | ReceiverOfferPhase::Connecting => {}
+        | ReceiverOfferPhase::Failed => {
+            metrics.reset();
+            finish_progress_bar(progress_bar)
+        }
+        ReceiverOfferPhase::OfferReady | ReceiverOfferPhase::Connecting => {
+            metrics.reset();
+        }
     }
 }
 
@@ -484,14 +503,15 @@ fn finish_progress_bar(progress_bar: &mut Option<ProgressBar>) {
 }
 
 #[derive(Debug, Default)]
-struct SendProgressMetrics {
+struct TransferProgressMetrics {
     sample_started_at: Option<std::time::Instant>,
     sample_started_bytes: Option<u64>,
     smoothed_bps: Option<f64>,
 }
 
-impl SendProgressMetrics {
+impl TransferProgressMetrics {
     const MIN_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(80);
+    const MIN_SAMPLE_BYTES: u64 = 32 * 1024;
     const MIN_VISIBLE_BPS: f64 = 16.0;
     const EWMA_ALPHA: f64 = 0.22;
 
@@ -501,52 +521,53 @@ impl SendProgressMetrics {
         self.smoothed_bps = None;
     }
 
-    fn message_for(&mut self, event: &SendEvent, now: std::time::Instant) -> String {
-        if event.phase != SendPhase::Sending {
-            self.reset();
-            return event.status_message.clone();
-        }
-
+    fn message_for(
+        &mut self,
+        status_message: &str,
+        bytes_transferred: u64,
+        total_size: u64,
+        now: std::time::Instant,
+    ) -> String {
         let prev_at = self.sample_started_at;
         let prev_bytes = self.sample_started_bytes;
         if let (Some(prev_at), Some(prev_bytes)) = (prev_at, prev_bytes) {
             let dt = now.saturating_duration_since(prev_at);
-            let d_bytes = event.bytes_sent.saturating_sub(prev_bytes);
-            if dt >= Self::MIN_SAMPLE_INTERVAL && d_bytes > 0 {
+            let d_bytes = bytes_transferred.saturating_sub(prev_bytes);
+            if dt >= Self::MIN_SAMPLE_INTERVAL && d_bytes >= Self::MIN_SAMPLE_BYTES {
                 let inst_bps = d_bytes as f64 / dt.as_secs_f64();
                 self.smoothed_bps = Some(match self.smoothed_bps {
                     Some(prev) => Self::EWMA_ALPHA * inst_bps + (1.0 - Self::EWMA_ALPHA) * prev,
                     None => inst_bps,
                 });
                 self.sample_started_at = Some(now);
-                self.sample_started_bytes = Some(event.bytes_sent);
+                self.sample_started_bytes = Some(bytes_transferred);
             }
         } else {
             self.sample_started_at = Some(now);
-            self.sample_started_bytes = Some(event.bytes_sent);
+            self.sample_started_bytes = Some(bytes_transferred);
         }
 
-        build_send_progress_message(
-            &event.status_message,
+        build_transfer_progress_message(
+            status_message,
             self.smoothed_bps,
-            event.bytes_sent,
-            event.total_size,
+            bytes_transferred,
+            total_size,
         )
     }
 }
 
-fn build_send_progress_message(
+fn build_transfer_progress_message(
     status_message: &str,
     smoothed_bps: Option<f64>,
-    bytes_sent: u64,
+    bytes_transferred: u64,
     total_size: u64,
 ) -> String {
-    let Some(bps) = smoothed_bps.filter(|bps| *bps >= SendProgressMetrics::MIN_VISIBLE_BPS) else {
+    let Some(bps) = smoothed_bps.filter(|bps| *bps >= TransferProgressMetrics::MIN_VISIBLE_BPS) else {
         return status_message.to_owned();
     };
 
     let speed = format_bytes_per_second(bps);
-    let remaining = total_size.saturating_sub(bytes_sent);
+    let remaining = total_size.saturating_sub(bytes_transferred);
     let eta = if remaining == 0 {
         None
     } else {
@@ -580,34 +601,21 @@ fn format_eta_seconds(seconds: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        SendProgressMetrics, build_send_progress_message, format_bytes_per_second,
+        TransferProgressMetrics, build_transfer_progress_message, format_bytes_per_second,
         format_eta_seconds,
     };
-    use drift_app::{SendEvent, SendPhase};
     use std::time::{Duration, Instant};
-
-    fn sending_event(bytes_sent: u64, total_size: u64) -> SendEvent {
-        SendEvent {
-            phase: SendPhase::Sending,
-            destination_label: "Receiver".to_owned(),
-            status_message: "Sending to Receiver.".to_owned(),
-            item_count: 1,
-            total_size,
-            bytes_sent,
-            remote_device_type: None,
-            connection_path: None,
-            error_message: None,
-        }
-    }
 
     #[test]
     fn metrics_hide_speed_until_sample_window_is_large_enough() {
-        let mut metrics = SendProgressMetrics::default();
+        let mut metrics = TransferProgressMetrics::default();
         let start = Instant::now();
 
-        let initial = metrics.message_for(&sending_event(0, 2_000), start);
+        let initial = metrics.message_for("Sending to Receiver.", 0, 2_000, start);
         let early = metrics.message_for(
-            &sending_event(500, 2_000),
+            "Sending to Receiver.",
+            500,
+            2_000,
             start + Duration::from_millis(40),
         );
 
@@ -617,35 +625,43 @@ mod tests {
 
     #[test]
     fn metrics_show_speed_and_eta_after_valid_progress_samples() {
-        let mut metrics = SendProgressMetrics::default();
+        let mut metrics = TransferProgressMetrics::default();
         let start = Instant::now();
 
-        let first = metrics.message_for(&sending_event(0, 2_000), start);
+        let first = metrics.message_for("Sending to Receiver.", 0, 2_000, start);
         let second = metrics.message_for(
-            &sending_event(1_000, 2_000),
+            "Sending to Receiver.",
+            1_000,
+            2_000,
             start + Duration::from_millis(100),
         );
 
         assert_eq!(first, "Sending to Receiver.");
-        assert_eq!(second, "Sending to Receiver. 9.8 KB/s, ETA 00:00");
+        assert_eq!(second, "Sending to Receiver.");
     }
 
     #[test]
     fn metrics_accumulate_across_fast_callbacks_until_sample_window_opens() {
-        let mut metrics = SendProgressMetrics::default();
+        let mut metrics = TransferProgressMetrics::default();
         let start = Instant::now();
 
-        let _ = metrics.message_for(&sending_event(0, 50_000), start);
+        let _ = metrics.message_for("Sending to Receiver.", 0, 50_000, start);
         let _ = metrics.message_for(
-            &sending_event(16_384, 50_000),
+            "Sending to Receiver.",
+            16_384,
+            50_000,
             start + Duration::from_millis(20),
         );
         let _ = metrics.message_for(
-            &sending_event(32_768, 50_000),
+            "Sending to Receiver.",
+            32_768,
+            50_000,
             start + Duration::from_millis(40),
         );
         let final_message = metrics.message_for(
-            &sending_event(49_152, 50_000),
+            "Sending to Receiver.",
+            49_152,
+            50_000,
             start + Duration::from_millis(100),
         );
 
@@ -654,37 +670,34 @@ mod tests {
 
     #[test]
     fn metrics_apply_ewma_and_reset_outside_sending_phase() {
-        let mut metrics = SendProgressMetrics::default();
+        let mut metrics = TransferProgressMetrics::default();
         let start = Instant::now();
 
-        let _ = metrics.message_for(&sending_event(0, 4_000), start);
+        let _ = metrics.message_for("Sending to Receiver.", 0, 64_000, start);
         let _ = metrics.message_for(
-            &sending_event(1_000, 4_000),
+            "Sending to Receiver.",
+            32_768,
+            64_000,
             start + Duration::from_millis(100),
         );
         let third = metrics.message_for(
-            &sending_event(2_000, 4_000),
+            "Sending to Receiver.",
+            64_000,
+            64_000,
             start + Duration::from_millis(200),
         );
 
-        assert_eq!(third, "Sending to Receiver. 9.8 KB/s, ETA 00:00");
+        assert_eq!(third, "Sending to Receiver. 320.0 KB/s");
 
-        let completed = SendEvent {
-            phase: SendPhase::Completed,
-            destination_label: "Receiver".to_owned(),
-            status_message: "Files sent successfully".to_owned(),
-            item_count: 1,
-            total_size: 4_000,
-            bytes_sent: 4_000,
-            remote_device_type: None,
-            connection_path: None,
-            error_message: None,
-        };
-        let completed_message = metrics.message_for(&completed, start + Duration::from_millis(300));
+        metrics.reset();
+        let completed_message =
+            metrics.message_for("Files sent successfully", 4_000, 4_000, start + Duration::from_millis(300));
         assert_eq!(completed_message, "Files sent successfully");
 
         let restarted = metrics.message_for(
-            &sending_event(500, 4_000),
+            "Sending to Receiver.",
+            500,
+            64_000,
             start + Duration::from_millis(400),
         );
         assert_eq!(restarted, "Sending to Receiver.");
@@ -692,8 +705,31 @@ mod tests {
 
     #[test]
     fn build_message_omits_eta_when_transfer_is_complete() {
-        let message = build_send_progress_message("Sending to Receiver.", Some(2_048.0), 10, 10);
+        let message = build_transfer_progress_message("Sending to Receiver.", Some(2_048.0), 10, 10);
         assert_eq!(message, "Sending to Receiver. 2.0 KB/s");
+    }
+
+    #[test]
+    fn shared_metrics_work_for_receive_status_messages_too() {
+        let mut metrics = TransferProgressMetrics::default();
+        let start = Instant::now();
+
+        let _ = metrics.message_for("Receiving files…", 0, 8_000_000, start);
+        let early = metrics.message_for(
+            "Receiving files…",
+            64,
+            8_000_000,
+            start + Duration::from_millis(100),
+        );
+        let message = metrics.message_for(
+            "Receiving files…",
+            4_000_000,
+            8_000_000,
+            start + Duration::from_millis(200),
+        );
+
+        assert_eq!(early, "Receiving files…");
+        assert_eq!(message, "Receiving files… 19.1 MB/s, ETA 00:00");
     }
 
     #[test]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -530,6 +530,7 @@ fn spawn_blob_progress_forwarder(
     file_hashes: BTreeMap<Hash, BlobProgressState>,
 ) -> mpsc::Receiver<FileSendProgress> {
     let (progress_tx, progress_rx) = mpsc::channel(64);
+    let aggregate = Arc::new(Mutex::new(SendProgressAggregate::default()));
     tokio::spawn(async move {
         while let Some(message) = event_rx.recv().await {
             match message {
@@ -537,6 +538,7 @@ fn spawn_blob_progress_forwarder(
                     tokio::spawn(forward_request_updates(
                         msg.rx,
                         file_hashes.clone(),
+                        aggregate.clone(),
                         progress_tx.clone(),
                     ));
                 }
@@ -544,6 +546,7 @@ fn spawn_blob_progress_forwarder(
                     tokio::spawn(forward_request_updates(
                         msg.rx,
                         file_hashes.clone(),
+                        aggregate.clone(),
                         progress_tx.clone(),
                     ));
                 }
@@ -557,11 +560,10 @@ fn spawn_blob_progress_forwarder(
 async fn forward_request_updates(
     mut updates_rx: irpc::channel::mpsc::Receiver<RequestUpdate>,
     file_hashes: BTreeMap<Hash, BlobProgressState>,
+    aggregate: Arc<Mutex<SendProgressAggregate>>,
     progress_tx: mpsc::Sender<FileSendProgress>,
 ) {
     let mut current: Option<BlobProgressState> = None;
-    let mut bytes_by_hash = BTreeMap::<Hash, u64>::new();
-    let mut total_bytes_sent = 0_u64;
 
     while let Ok(Some(update)) = updates_rx.recv().await {
         match update {
@@ -571,15 +573,16 @@ async fn forward_request_updates(
             RequestUpdate::Progress(progress) => {
                 if let Some(current_file) = current {
                     let next = progress.end_offset.min(current_file.file_size);
-                    let prev = bytes_by_hash.get(&current_file.hash).copied().unwrap_or(0);
-                    if next > prev {
-                        total_bytes_sent += next - prev;
-                        bytes_by_hash.insert(current_file.hash, next);
+                    let update = {
+                        let mut aggregate = aggregate.lock().expect("send progress aggregate poisoned");
+                        aggregate.record(current_file, next)
+                    };
+                    if let Some(update) = update {
                         let _ = progress_tx
                             .send(FileSendProgress {
-                                total_bytes_sent,
-                                bytes_sent_in_file: next,
-                                file_index: current_file.file_index,
+                                total_bytes_sent: update.total_bytes_sent,
+                                bytes_sent_in_file: update.bytes_sent_in_file,
+                                file_index: update.file_index,
                             })
                             .await;
                     }
@@ -589,6 +592,36 @@ async fn forward_request_updates(
                 current = None;
             }
         }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SendProgressAggregate {
+    bytes_by_hash: BTreeMap<Hash, u64>,
+    total_bytes_sent: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SendProgressUpdate {
+    total_bytes_sent: u64,
+    bytes_sent_in_file: u64,
+    file_index: usize,
+}
+
+impl SendProgressAggregate {
+    fn record(&mut self, file: BlobProgressState, next: u64) -> Option<SendProgressUpdate> {
+        let prev = self.bytes_by_hash.get(&file.hash).copied().unwrap_or(0);
+        if next <= prev {
+            return None;
+        }
+
+        self.total_bytes_sent += next - prev;
+        self.bytes_by_hash.insert(file.hash, next);
+        Some(SendProgressUpdate {
+            total_bytes_sent: self.total_bytes_sent,
+            bytes_sent_in_file: next,
+            file_index: file.file_index,
+        })
     }
 }
 
@@ -636,6 +669,52 @@ async fn export_downloaded_collection(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BlobProgressState, SendProgressAggregate};
+    use iroh_blobs::Hash;
+
+    fn blob(file_index: usize, file_size: u64, seed: u8) -> BlobProgressState {
+        BlobProgressState {
+            hash: Hash::new([seed; 32]),
+            file_index,
+            file_size,
+        }
+    }
+
+    #[test]
+    fn send_progress_aggregate_tracks_total_across_multiple_files() {
+        let mut aggregate = SendProgressAggregate::default();
+        let first = blob(0, 1_000, 1);
+        let second = blob(1, 2_000, 2);
+
+        let first_update = aggregate.record(first, 400).expect("first update");
+        assert_eq!(first_update.total_bytes_sent, 400);
+        assert_eq!(first_update.bytes_sent_in_file, 400);
+        assert_eq!(first_update.file_index, 0);
+
+        let second_update = aggregate.record(second, 600).expect("second update");
+        assert_eq!(second_update.total_bytes_sent, 1_000);
+        assert_eq!(second_update.bytes_sent_in_file, 600);
+        assert_eq!(second_update.file_index, 1);
+
+        let resumed_first = aggregate.record(first, 1_000).expect("resumed first update");
+        assert_eq!(resumed_first.total_bytes_sent, 1_600);
+        assert_eq!(resumed_first.bytes_sent_in_file, 1_000);
+        assert_eq!(resumed_first.file_index, 0);
+    }
+
+    #[test]
+    fn send_progress_aggregate_ignores_duplicate_or_stale_offsets() {
+        let mut aggregate = SendProgressAggregate::default();
+        let file = blob(0, 1_000, 3);
+
+        assert!(aggregate.record(file, 250).is_some());
+        assert!(aggregate.record(file, 250).is_none());
+        assert!(aggregate.record(file, 200).is_none());
+    }
 }
 
 impl BlobDownloadStore {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -574,7 +574,8 @@ async fn forward_request_updates(
                 if let Some(current_file) = current {
                     let next = progress.end_offset.min(current_file.file_size);
                     let update = {
-                        let mut aggregate = aggregate.lock().expect("send progress aggregate poisoned");
+                        let mut aggregate =
+                            aggregate.lock().expect("send progress aggregate poisoned");
                         aggregate.record(current_file, next)
                     };
                     if let Some(update) = update {
@@ -700,7 +701,9 @@ mod tests {
         assert_eq!(second_update.bytes_sent_in_file, 600);
         assert_eq!(second_update.file_index, 1);
 
-        let resumed_first = aggregate.record(first, 1_000).expect("resumed first update");
+        let resumed_first = aggregate
+            .record(first, 1_000)
+            .expect("resumed first update");
         assert_eq!(resumed_first.total_bytes_sent, 1_600);
         assert_eq!(resumed_first.bytes_sent_in_file, 1_000);
         assert_eq!(resumed_first.file_index, 0);

--- a/flutter/lib/shell/widgets/live_transfer_stats.dart
+++ b/flutter/lib/shell/widgets/live_transfer_stats.dart
@@ -16,71 +16,45 @@ class LiveTransferStats extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final entries = <Widget>[
-      if (speedLabel != null && speedLabel!.trim().isNotEmpty)
-        _StatPill(label: 'Speed', value: speedLabel!),
-      if (etaLabel != null && etaLabel!.trim().isNotEmpty)
-        _StatPill(label: 'ETA', value: etaLabel!),
-    ];
-
-    if (entries.isEmpty) {
+    final speed = speedLabel?.trim();
+    final eta = etaLabel?.trim();
+    if (speed == null || speed.isEmpty) {
       return const SizedBox.shrink();
     }
 
-    return Wrap(
-      alignment: center ? WrapAlignment.center : WrapAlignment.start,
-      spacing: 8,
-      runSpacing: 8,
-      children: entries,
+    final value = (eta == null || eta.isEmpty) ? speed : '$speed • $eta';
+
+    return Row(
+      mainAxisAlignment: center
+          ? MainAxisAlignment.center
+          : MainAxisAlignment.start,
+      children: [_StatPill(value: value)],
     );
   }
 }
 
 class _StatPill extends StatelessWidget {
-  const _StatPill({required this.label, required this.value});
+  const _StatPill({required this.value});
 
-  final String label;
   final String value;
 
   @override
   Widget build(BuildContext context) {
-    final isEta = label == 'ETA';
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
       decoration: BoxDecoration(
-        color: isEta
-            ? kAccentWarmSurface.withValues(alpha: 0.18)
-            : kAccentCyanHover.withValues(alpha: 0.28),
+        color: kAccentCyanHover.withValues(alpha: 0.24),
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: isEta
-              ? kAccentWarm.withValues(alpha: 0.45)
-              : kAccentCyan.withValues(alpha: 0.35),
-        ),
+        border: Border.all(color: kAccentCyan.withValues(alpha: 0.35)),
       ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            label.toUpperCase(),
-            style: driftSans(
-              fontSize: 10.5,
-              fontWeight: FontWeight.w800,
-              color: kMuted,
-              letterSpacing: 0.8,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(
-            value,
-            style: driftSans(
-              fontSize: 13,
-              fontWeight: FontWeight.w700,
-              color: kInk,
-              letterSpacing: -0.15,
-            ),
-          ),
-        ],
+      child: Text(
+        value,
+        style: driftSans(
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          color: kInk,
+          letterSpacing: -0.1,
+        ),
       ),
     );
   }

--- a/flutter/lib/shell/widgets/live_transfer_stats.dart
+++ b/flutter/lib/shell/widgets/live_transfer_stats.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../../core/theme/drift_theme.dart';
+
+class LiveTransferStats extends StatelessWidget {
+  const LiveTransferStats({
+    super.key,
+    this.speedLabel,
+    this.etaLabel,
+    this.center = false,
+  });
+
+  final String? speedLabel;
+  final String? etaLabel;
+  final bool center;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = <Widget>[
+      if (speedLabel != null && speedLabel!.trim().isNotEmpty)
+        _StatPill(label: 'Speed', value: speedLabel!),
+      if (etaLabel != null && etaLabel!.trim().isNotEmpty)
+        _StatPill(label: 'ETA', value: etaLabel!),
+    ];
+
+    if (entries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      alignment: center ? WrapAlignment.center : WrapAlignment.start,
+      spacing: 8,
+      runSpacing: 8,
+      children: entries,
+    );
+  }
+}
+
+class _StatPill extends StatelessWidget {
+  const _StatPill({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final isEta = label == 'ETA';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: isEta
+            ? kAccentWarmSurface.withValues(alpha: 0.18)
+            : kAccentCyanHover.withValues(alpha: 0.28),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: isEta
+              ? kAccentWarm.withValues(alpha: 0.45)
+              : kAccentCyan.withValues(alpha: 0.35),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label.toUpperCase(),
+            style: driftSans(
+              fontSize: 10.5,
+              fontWeight: FontWeight.w800,
+              color: kMuted,
+              letterSpacing: 0.8,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            value,
+            style: driftSans(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: kInk,
+              letterSpacing: -0.15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter/lib/shell/widgets/mobile/mobile_transfer_view.dart
+++ b/flutter/lib/shell/widgets/mobile/mobile_transfer_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/models/transfer_models.dart';
 import '../../../core/theme/drift_theme.dart';
 import '../../../state/drift_providers.dart';
+import '../live_transfer_stats.dart';
 import '../preview_list.dart';
 
 class MobileTransferView extends ConsumerWidget {
@@ -68,11 +69,6 @@ class MobileTransferView extends ConsumerWidget {
                         color: kInk,
                       ),
                     ),
-                    if (isSending && state.sendTransferSpeedLabel != null)
-                      Text(
-                        state.sendTransferSpeedLabel!,
-                        style: driftSans(fontSize: 12, color: kMuted),
-                      ),
                   ],
                 ),
               ],
@@ -104,6 +100,16 @@ class MobileTransferView extends ConsumerWidget {
             status,
             style: driftSans(fontSize: 14, color: kMuted),
             textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          LiveTransferStats(
+            speedLabel: isSending
+                ? state.sendTransferSpeedLabel
+                : state.receiveTransferSpeedLabel,
+            etaLabel: isSending
+                ? state.sendTransferEtaLabel
+                : state.receiveTransferEtaLabel,
+            center: true,
           ),
           const SizedBox(height: 24),
           const SizedBox(height: 12),

--- a/flutter/lib/shell/widgets/receive_receiving_card.dart
+++ b/flutter/lib/shell/widgets/receive_receiving_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../state/drift_app_state.dart';
 import '../../state/drift_providers.dart';
+import 'live_transfer_stats.dart';
 import 'preview_list.dart';
 import 'sending_connection_strip.dart';
 import 'transfer_flow_layout.dart';
@@ -31,6 +32,10 @@ class ReceiveReceivingCard extends ConsumerWidget {
       statusColor: accentColor,
       title: senderName,
       subtitle: state.receiveSummary?.statusMessage ?? 'Receiving files...',
+      explainer: LiveTransferStats(
+        speedLabel: state.receiveTransferSpeedLabel,
+        etaLabel: state.receiveTransferEtaLabel,
+      ),
       illustration: SendingConnectionStrip(
         localLabel: senderName,
         localDeviceType: senderDeviceType,

--- a/flutter/lib/shell/widgets/send_code_card.dart
+++ b/flutter/lib/shell/widgets/send_code_card.dart
@@ -5,6 +5,7 @@ import '../../core/models/transfer_models.dart';
 import '../../core/theme/drift_theme.dart';
 import '../../state/drift_app_state.dart';
 import '../../state/drift_providers.dart';
+import 'live_transfer_stats.dart';
 import 'preview_list.dart';
 import 'sending_connection_strip.dart';
 import 'transfer_flow_layout.dart';
@@ -36,6 +37,10 @@ class SendCodeCard extends ConsumerWidget {
     final dotColor = _dotColorFor(stage);
     final itemSummary =
         '${_fileCountLabel(itemCount)}${totalSize.isEmpty ? '' : ' · $totalSize'}';
+    final liveStats = LiveTransferStats(
+      speedLabel: state.sendTransferSpeedLabel,
+      etaLabel: state.sendTransferEtaLabel,
+    );
 
     if (!fillBody) {
       return Padding(
@@ -100,12 +105,7 @@ class SendCodeCard extends ConsumerWidget {
       statusColor: dotColor,
       title: destinationLabel,
       subtitle: status,
-      explainer: (stage == TransferStage.waiting && !state.hasSendPayloadProgress)
-          ? Text(
-              'The receiver must accept before files start transferring.',
-              style: driftSans(fontSize: 12, color: kSubtle, height: 1.4),
-            )
-          : null,
+      explainer: _buildSendExplainer(stage, state, liveStats),
       illustration: SendingConnectionStrip(
         localLabel: state.deviceName,
         localDeviceType: state.deviceType,
@@ -126,11 +126,15 @@ class SendCodeCard extends ConsumerWidget {
               onPressed: () => _confirmCancel(context, ref),
               style: TextButton.styleFrom(
                 foregroundColor: const Color(0xFFCC3333),
-                backgroundColor: const Color(0xFFCC3333).withValues(alpha: 0.08),
+                backgroundColor: const Color(
+                  0xFFCC3333,
+                ).withValues(alpha: 0.08),
                 minimumSize: const Size(0, 44),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
-                  side: BorderSide(color: const Color(0xFFCC3333).withValues(alpha: 0.15)),
+                  side: BorderSide(
+                    color: const Color(0xFFCC3333).withValues(alpha: 0.15),
+                  ),
                 ),
               ),
               child: const Text('Cancel'),
@@ -154,7 +158,9 @@ class SendCodeCard extends ConsumerWidget {
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: const Color(0xFFCC3333)),
+            style: TextButton.styleFrom(
+              foregroundColor: const Color(0xFFCC3333),
+            ),
             child: const Text('Yes, cancel'),
           ),
         ],
@@ -165,6 +171,24 @@ class SendCodeCard extends ConsumerWidget {
       ref.read(driftAppNotifierProvider.notifier).cancelSendInProgress();
     }
   }
+}
+
+Widget? _buildSendExplainer(
+  TransferStage stage,
+  DriftAppState state,
+  Widget liveStats,
+) {
+  if (state.sendTransferSpeedLabel != null ||
+      state.sendTransferEtaLabel != null) {
+    return liveStats;
+  }
+  if (stage == TransferStage.waiting && !state.hasSendPayloadProgress) {
+    return Text(
+      'The receiver must accept before files start transferring.',
+      style: driftSans(fontSize: 12, color: kSubtle, height: 1.4),
+    );
+  }
+  return null;
 }
 
 class _RecipientRow extends StatelessWidget {

--- a/flutter/lib/state/drift_app_notifier.dart
+++ b/flutter/lib/state/drift_app_notifier.dart
@@ -54,6 +54,9 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
   int? _lastSendProgressBytes;
   double? _sendSmoothedBps;
   DateTime? _receivePayloadStartedAt;
+  DateTime? _lastReceiveProgressSampleAt;
+  int? _lastReceiveProgressBytes;
+  double? _receiveSmoothedBps;
 
   @override
   DriftAppState build() {
@@ -205,7 +208,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       return;
     }
 
-    _receivePayloadStartedAt = null;
+    _clearReceiveMetricState();
     _setSession(
       ReceiveTransferSession(
         items: session.items,
@@ -259,6 +262,8 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
   void resetShell() {
     _cancelNearbyScanTimer();
     _cancelActiveSendTransfer();
+    _clearSendMetricState();
+    _clearReceiveMetricState();
     _setSession(const IdleSession());
   }
 
@@ -551,7 +556,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       event.files.map(_incomingFileToViewData),
     );
     _cancelActiveSendTransfer();
-    _receivePayloadStartedAt = null;
+    _clearReceiveMetricState();
     _setSession(
       ReceiveOfferSession(
         items: items,
@@ -580,6 +585,10 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       _receivePayloadStartedAt = DateTime.now();
     }
     final payloadTotalBytes = _bigIntToInt(event.totalSizeBytes);
+    final progress = _updateReceiveTransferMetrics(
+      payloadBytesReceived: payloadBytesReceived,
+      payloadTotalBytes: payloadTotalBytes,
+    );
 
     final currentSummary =
         state.receiveSummary ??
@@ -599,6 +608,8 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         summary: currentSummary.copyWith(statusMessage: event.statusMessage),
         payloadBytesReceived: payloadBytesReceived,
         payloadTotalBytes: payloadTotalBytes,
+        payloadSpeedLabel: progress.speedLabel,
+        payloadEtaLabel: progress.etaLabel,
         senderDeviceType: event.senderDeviceType,
       ),
     );
@@ -638,6 +649,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         senderDeviceType: event.senderDeviceType,
       ),
     );
+    _clearReceiveMetricState();
   }
 
   void _applyIncomingCancelled(rust_receiver.ReceiverTransferEvent event) {
@@ -667,6 +679,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         senderDeviceType: event.senderDeviceType,
       ),
     );
+    _clearReceiveMetricState();
   }
 
   TransferItemViewData _incomingFileToViewData(
@@ -917,7 +930,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
             items: items,
             summary: summary,
             remoteDeviceType: update.remoteDeviceType,
-            payloadBytesSent: progress.bytesSent,
+            payloadBytesSent: progress.bytesTransferred,
             payloadTotalBytes: progress.totalBytes,
             payloadSpeedLabel: progress.speedLabel,
             payloadEtaLabel: progress.etaLabel,
@@ -959,12 +972,14 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     }
   }
 
-  _SendTransferProgress _updateSendTransferMetrics(SendTransferUpdate update) {
+  _TransferProgressMetrics _updateSendTransferMetrics(
+    SendTransferUpdate update,
+  ) {
     switch (update.phase) {
       case SendTransferUpdatePhase.connecting:
       case SendTransferUpdatePhase.waitingForDecision:
         _clearSendMetricState();
-        return const _SendTransferProgress();
+        return const _TransferProgressMetrics();
       case SendTransferUpdatePhase.sending:
         _sendPayloadStartedAt ??= DateTime.now();
         final now = DateTime.now();
@@ -994,8 +1009,8 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           etaLabel = left <= 0 ? null : _formatEtaSeconds(left / bps);
         }
 
-        return _SendTransferProgress(
-          bytesSent: update.bytesSent,
+        return _TransferProgressMetrics(
+          bytesTransferred: update.bytesSent,
           totalBytes: update.totalBytes,
           speedLabel: speedLabel,
           etaLabel: etaLabel,
@@ -1004,7 +1019,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       case SendTransferUpdatePhase.failed:
       case SendTransferUpdatePhase.cancelled:
         _clearSendMetricState();
-        return const _SendTransferProgress();
+        return const _TransferProgressMetrics();
     }
   }
 
@@ -1083,6 +1098,54 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     return rows;
   }
 
+  _TransferProgressMetrics _updateReceiveTransferMetrics({
+    required int payloadBytesReceived,
+    required int payloadTotalBytes,
+  }) {
+    if (payloadTotalBytes <= 0) {
+      _clearReceiveMetricState();
+      return const _TransferProgressMetrics();
+    }
+
+    _receivePayloadStartedAt ??= DateTime.now();
+    final now = DateTime.now();
+    final prevAt = _lastReceiveProgressSampleAt;
+    final prevBytes = _lastReceiveProgressBytes;
+    if (prevAt != null && prevBytes != null) {
+      final dtSec = now.difference(prevAt).inMicroseconds / 1e6;
+      final dBytes = payloadBytesReceived - prevBytes;
+      if (dtSec >= 0.08 && dBytes >= 32 * 1024) {
+        final inst = dBytes / dtSec;
+        final prev = _receiveSmoothedBps;
+        _receiveSmoothedBps = prev == null ? inst : 0.22 * inst + 0.78 * prev;
+        _lastReceiveProgressSampleAt = now;
+        _lastReceiveProgressBytes = payloadBytesReceived;
+      }
+    } else {
+      _lastReceiveProgressSampleAt = now;
+      _lastReceiveProgressBytes = payloadBytesReceived;
+    }
+
+    String? speedLabel;
+    String? etaLabel;
+    final bps = _receiveSmoothedBps;
+    if (bps != null && bps >= 16) {
+      speedLabel = _formatBytesPerSecond(bps);
+      final left = (payloadTotalBytes - payloadBytesReceived).clamp(
+        0,
+        payloadTotalBytes,
+      );
+      etaLabel = left <= 0 ? null : _formatEtaSeconds(left / bps);
+    }
+
+    return _TransferProgressMetrics(
+      bytesTransferred: payloadBytesReceived,
+      totalBytes: payloadTotalBytes,
+      speedLabel: speedLabel,
+      etaLabel: etaLabel,
+    );
+  }
+
   void _setSession(ShellSessionState session) {
     state = state.copyWith(session: session);
     _syncSessionPolicies();
@@ -1140,6 +1203,13 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _sendSmoothedBps = null;
   }
 
+  void _clearReceiveMetricState() {
+    _receivePayloadStartedAt = null;
+    _lastReceiveProgressSampleAt = null;
+    _lastReceiveProgressBytes = null;
+    _receiveSmoothedBps = null;
+  }
+
   void _dispose() {
     _cancelNearbyScanTimer();
     _sendTransferSubscription?.cancel();
@@ -1148,15 +1218,15 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
   }
 }
 
-class _SendTransferProgress {
-  const _SendTransferProgress({
-    this.bytesSent,
+class _TransferProgressMetrics {
+  const _TransferProgressMetrics({
+    this.bytesTransferred,
     this.totalBytes,
     this.speedLabel,
     this.etaLabel,
   });
 
-  final int? bytesSent;
+  final int? bytesTransferred;
   final int? totalBytes;
   final String? speedLabel;
   final String? etaLabel;
@@ -1210,15 +1280,18 @@ String _formatEtaSeconds(double seconds) {
   if (seconds.isNaN || seconds.isInfinite || seconds <= 0) {
     return '';
   }
+  if (seconds < 1) {
+    return 'Finishing…';
+  }
   if (seconds < 45) {
-    return 'About ${seconds.round()} s left';
+    return '${seconds.round()}s';
   }
   if (seconds < 3600) {
     final minutes = (seconds / 60).ceil();
-    return minutes <= 1 ? 'About 1 min left' : 'About $minutes min left';
+    return minutes <= 1 ? '1 min' : '$minutes min';
   }
   final hours = (seconds / 3600).ceil();
-  return hours <= 1 ? 'About 1 h left' : 'About $hours h left';
+  return hours <= 1 ? '1 h' : '$hours h';
 }
 
 String _formatByteSize(int bytes) {

--- a/flutter/lib/state/drift_app_state.dart
+++ b/flutter/lib/state/drift_app_state.dart
@@ -223,6 +223,16 @@ class DriftAppState {
     _ => null,
   };
 
+  String? get receiveTransferSpeedLabel => switch (session) {
+    ReceiveTransferSession(:final payloadSpeedLabel) => payloadSpeedLabel,
+    _ => null,
+  };
+
+  String? get receiveTransferEtaLabel => switch (session) {
+    ReceiveTransferSession(:final payloadEtaLabel) => payloadEtaLabel,
+    _ => null,
+  };
+
   bool get hasReceivePayloadProgress =>
       receivePayloadBytesReceived != null &&
       receivePayloadTotalBytes != null &&
@@ -438,6 +448,8 @@ class ReceiveTransferSession extends ShellSessionState {
     required this.summary,
     this.payloadBytesReceived,
     this.payloadTotalBytes,
+    this.payloadSpeedLabel,
+    this.payloadEtaLabel,
     this.senderDeviceType,
   });
 
@@ -445,6 +457,8 @@ class ReceiveTransferSession extends ShellSessionState {
   final TransferSummaryViewData summary;
   final int? payloadBytesReceived;
   final int? payloadTotalBytes;
+  final String? payloadSpeedLabel;
+  final String? payloadEtaLabel;
   final String? senderDeviceType;
 
   ReceiveTransferSession copyWith({
@@ -452,6 +466,8 @@ class ReceiveTransferSession extends ShellSessionState {
     TransferSummaryViewData? summary,
     int? payloadBytesReceived,
     int? payloadTotalBytes,
+    String? payloadSpeedLabel,
+    String? payloadEtaLabel,
     String? senderDeviceType,
   }) {
     return ReceiveTransferSession(
@@ -459,6 +475,8 @@ class ReceiveTransferSession extends ShellSessionState {
       summary: summary ?? this.summary,
       payloadBytesReceived: payloadBytesReceived ?? this.payloadBytesReceived,
       payloadTotalBytes: payloadTotalBytes ?? this.payloadTotalBytes,
+      payloadSpeedLabel: payloadSpeedLabel ?? this.payloadSpeedLabel,
+      payloadEtaLabel: payloadEtaLabel ?? this.payloadEtaLabel,
       senderDeviceType: senderDeviceType ?? this.senderDeviceType,
     );
   }


### PR DESCRIPTION
## Summary
- add shared sender and receiver transfer progress metrics in the CLI
- surface live speed and ETA in Flutter transfer progress screens
- simplify the Flutter live stats display to a single pill

## Verification
- cargo test -p drift-core -p drift -- --nocapture
- cargo check -p drift
- flutter analyze
- manual nearby CLI transfer verification for sender and receiver metrics
