### PR TITLE
ci: automate releases and use versioned DMGs for macOS

### DIFF
--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -191,8 +191,12 @@ jobs:
       - name: Build Windows app
         run: flutter build windows --release
 
-      - name: Create MSIX package
-        run: dart run msix:create
+      - name: Build Windows Installer (Inno Setup)
+        shell: pwsh
+        run: |
+          $version = (Get-Content pubspec.yaml | Select-String "^version: ").ToString().Split(" ")[1].Split("+")[0]
+          & "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /DAppVersion=$version windows/inno_setup.iss
+          Move-Item windows/drift-windows-setup.exe "drift-windows-setup-${env:SAFE_VERSION}.exe"
 
       - name: Package portable Windows zip
         shell: pwsh
@@ -201,11 +205,11 @@ jobs:
           $zipPath = Join-Path $PWD "drift-windows-portable-${env:SAFE_VERSION}.zip"
           Compress-Archive -Path (Join-Path $releaseDir '*') -DestinationPath $zipPath -Force
 
-      - name: Upload Windows MSIX
+      - name: Upload Windows Setup EXE
         uses: actions/upload-artifact@v4
         with:
-          name: drift-windows-msix
-          path: flutter/build/windows/x64/runner/Release/*.msix
+          name: drift-windows-setup
+          path: flutter/drift-windows-setup-${{ env.SAFE_VERSION }}.exe
           if-no-files-found: error
 
       - name: Upload Windows portable zip
@@ -293,7 +297,7 @@ jobs:
         run: |
           mkdir release-dist
           find artifacts -name "*.zip" -exec mv {} release-dist/ \;
-          find artifacts -name "*.msix" -exec mv {} release-dist/ \;
+          find artifacts -name "*.exe" -exec mv {} release-dist/ \;
           find artifacts -name "*.apk" -exec mv {} release-dist/ \;
           find artifacts -name "*.dmg" -exec mv {} release-dist/ \;
 

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -146,7 +146,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drift-linux
-          path: drift-linux-${{ env.SAFE_VERSION }}.zip
+          path: flutter/drift-linux-${{ env.SAFE_VERSION }}.zip
           if-no-files-found: error
 
   windows:

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -29,6 +29,9 @@ jobs:
             Cargo.toml
             Cargo.lock
 
+      - name: Set Safe Version Name
+        run: echo "SAFE_VERSION=$(echo ${{ github.ref_name }} | tr '/' '-')" >> $GITHUB_ENV
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -61,7 +64,7 @@ jobs:
         run: |
           npm install --global create-dmg
           create-dmg build/macos/Build/Products/Release/Drift.app --no-code-sign || true
-          mv Drift\ *.dmg ../drift-macos-${{ github.ref_name }}.dmg
+          mv Drift\ *.dmg "drift-macos-${{ env.SAFE_VERSION }}.dmg"
 
       - name: Build iOS (no code signing)
         run: flutter build ios --release --no-codesign
@@ -69,20 +72,20 @@ jobs:
       - name: Package iOS zip
         run: |
           cd build/ios/Release-iphoneos
-          zip -r ../../../drift-ios-unsigned-${{ github.ref_name }}.zip Runner.app
+          zip -r "../../../drift-ios-unsigned-${{ env.SAFE_VERSION }}.zip" Runner.app
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
           name: drift-macos
-          path: drift-macos-${{ github.ref_name }}.dmg
+          path: flutter/drift-macos-${{ env.SAFE_VERSION }}.dmg
           if-no-files-found: error
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v4
         with:
           name: drift-ios-unsigned
-          path: flutter/drift-ios-unsigned-${{ github.ref_name }}.zip
+          path: flutter/drift-ios-unsigned-${{ env.SAFE_VERSION }}.zip
           if-no-files-found: error
 
   linux:
@@ -100,6 +103,9 @@ jobs:
             crates
             Cargo.toml
             Cargo.lock
+
+      - name: Set Safe Version Name
+        run: echo "SAFE_VERSION=$(echo ${{ github.ref_name }} | tr '/' '-')" >> $GITHUB_ENV
 
       - name: Install Linux desktop build dependencies
         run: |
@@ -134,13 +140,13 @@ jobs:
       - name: Package Linux zip
         run: |
           cd build/linux/x64/release
-          zip -r ../../../../drift-linux-${{ github.ref_name }}.zip bundle
+          zip -r "../../../../drift-linux-${{ env.SAFE_VERSION }}.zip" bundle
 
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
           name: drift-linux
-          path: flutter/drift-linux-${{ github.ref_name }}.zip
+          path: drift-linux-${{ env.SAFE_VERSION }}.zip
           if-no-files-found: error
 
   windows:
@@ -158,6 +164,9 @@ jobs:
             crates
             Cargo.toml
             Cargo.lock
+
+      - name: Set Safe Version Name
+        run: echo "SAFE_VERSION=$(echo ${{ github.ref_name }} | tr '/' '-')" >> $GITHUB_ENV
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -189,7 +198,7 @@ jobs:
         shell: pwsh
         run: |
           $releaseDir = Join-Path $PWD "build/windows/x64/runner/Release"
-          $zipPath = Join-Path $PWD "drift-windows-portable-${{ github.ref_name }}.zip"
+          $zipPath = Join-Path $PWD "drift-windows-portable-${env:SAFE_VERSION}.zip"
           Compress-Archive -Path (Join-Path $releaseDir '*') -DestinationPath $zipPath -Force
 
       - name: Upload Windows MSIX
@@ -203,7 +212,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drift-windows-portable
-          path: flutter/drift-windows-portable-${{ github.ref_name }}.zip
+          path: flutter/drift-windows-portable-${{ env.SAFE_VERSION }}.zip
           if-no-files-found: error
 
   android:
@@ -221,6 +230,9 @@ jobs:
             crates
             Cargo.toml
             Cargo.lock
+
+      - name: Set Safe Version Name
+        run: echo "SAFE_VERSION=$(echo ${{ github.ref_name }} | tr '/' '-')" >> $GITHUB_ENV
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -255,13 +267,13 @@ jobs:
         run: flutter build apk --release
 
       - name: Package Android APK
-        run: mv build/app/outputs/flutter-apk/app-release.apk drift-android-${{ github.ref_name }}.apk
+        run: mv build/app/outputs/flutter-apk/app-release.apk "drift-android-${{ env.SAFE_VERSION }}.apk"
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
         with:
           name: drift-android
-          path: flutter/drift-android-${{ github.ref_name }}.apk
+          path: flutter/drift-android-${{ env.SAFE_VERSION }}.apk
           if-no-files-found: error
 
   create_release:

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -29,6 +29,11 @@ jobs:
             Cargo.toml
             Cargo.lock
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -52,10 +57,11 @@ jobs:
       - name: Build macOS app
         run: flutter build macos --release
 
-      - name: Package macOS zip
+      - name: Create macOS DMG
         run: |
-          cd build/macos/Build/Products/Release
-          zip -r ../../../../drift-macos-${{ github.ref_name }}.zip Drift.app
+          npm install --global create-dmg
+          create-dmg build/macos/Build/Products/Release/Drift.app --no-code-sign || true
+          mv Drift\ *.dmg ../drift-macos-${{ github.ref_name }}.dmg
 
       - name: Build iOS (no code signing)
         run: flutter build ios --release --no-codesign
@@ -69,7 +75,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drift-macos
-          path: flutter/drift-macos-${{ github.ref_name }}.zip
+          path: drift-macos-${{ github.ref_name }}.dmg
           if-no-files-found: error
 
       - name: Upload iOS artifact
@@ -277,6 +283,7 @@ jobs:
           find artifacts -name "*.zip" -exec mv {} release-dist/ \;
           find artifacts -name "*.msix" -exec mv {} release-dist/ \;
           find artifacts -name "*.apk" -exec mv {} release-dist/ \;
+          find artifacts -name "*.dmg" -exec mv {} release-dist/ \;
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/flutter-release.yml
+++ b/.github/workflows/flutter-release.yml
@@ -3,6 +3,7 @@ name: Flutter release (all platforms)
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -20,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             flutter
@@ -51,21 +52,31 @@ jobs:
       - name: Build macOS app
         run: flutter build macos --release
 
+      - name: Package macOS zip
+        run: |
+          cd build/macos/Build/Products/Release
+          zip -r ../../../../drift-macos-${{ github.ref_name }}.zip Drift.app
+
       - name: Build iOS (no code signing)
         run: flutter build ios --release --no-codesign
+
+      - name: Package iOS zip
+        run: |
+          cd build/ios/Release-iphoneos
+          zip -r ../../../drift-ios-unsigned-${{ github.ref_name }}.zip Runner.app
 
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: drift-macos-app
-          path: flutter/build/macos/Build/Products/Release/Drift.app
+          name: drift-macos
+          path: flutter/drift-macos-${{ github.ref_name }}.zip
           if-no-files-found: error
 
       - name: Upload iOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: drift-ios-app-unsigned
-          path: flutter/build/ios/Release-iphoneos/Runner.app
+          name: drift-ios-unsigned
+          path: flutter/drift-ios-unsigned-${{ github.ref_name }}.zip
           if-no-files-found: error
 
   linux:
@@ -76,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             flutter
@@ -114,11 +125,16 @@ jobs:
       - name: Build Linux app
         run: flutter build linux --release
 
+      - name: Package Linux zip
+        run: |
+          cd build/linux/x64/release
+          zip -r ../../../../drift-linux-${{ github.ref_name }}.zip bundle
+
       - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
-          name: drift-linux-bundle
-          path: flutter/build/linux/x64/release/bundle
+          name: drift-linux
+          path: flutter/drift-linux-${{ github.ref_name }}.zip
           if-no-files-found: error
 
   windows:
@@ -129,7 +145,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             flutter
@@ -167,10 +183,7 @@ jobs:
         shell: pwsh
         run: |
           $releaseDir = Join-Path $PWD "build/windows/x64/runner/Release"
-          $zipPath = Join-Path $releaseDir "drift-windows.zip"
-          if (Test-Path $zipPath) {
-            Remove-Item $zipPath -Force
-          }
+          $zipPath = Join-Path $PWD "drift-windows-portable-${{ github.ref_name }}.zip"
           Compress-Archive -Path (Join-Path $releaseDir '*') -DestinationPath $zipPath -Force
 
       - name: Upload Windows MSIX
@@ -184,7 +197,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drift-windows-portable
-          path: flutter/build/windows/x64/runner/Release/drift-windows.zip
+          path: flutter/drift-windows-portable-${{ github.ref_name }}.zip
           if-no-files-found: error
 
   android:
@@ -195,7 +208,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             flutter
@@ -235,9 +248,40 @@ jobs:
       - name: Build Android APK
         run: flutter build apk --release
 
+      - name: Package Android APK
+        run: mv build/app/outputs/flutter-apk/app-release.apk drift-android-${{ github.ref_name }}.apk
+
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
         with:
-          name: drift-android-apk
-          path: flutter/build/app/outputs/flutter-apk/app-release.apk
+          name: drift-android
+          path: flutter/drift-android-${{ github.ref_name }}.apk
           if-no-files-found: error
+
+  create_release:
+    name: Create GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [macos_ios, linux, windows, android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release files
+        run: |
+          mkdir release-dist
+          find artifacts -name "*.zip" -exec mv {} release-dist/ \;
+          find artifacts -name "*.msix" -exec mv {} release-dist/ \;
+          find artifacts -name "*.apk" -exec mv {} release-dist/ \;
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-dist/*
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             flutter

--- a/.github/workflows/rust-core.yml
+++ b/.github/workflows/rust-core.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -73,16 +73,6 @@ flutter_launcher_icons:
     generate: true
     image_path: "assets/logo.png"
 
-msix_config:
-  display_name: Drift
-  publisher_display_name: Drift
-  identity_name: dev.drift.app
-  msix_version: 1.0.0.1
-  logo_path: assets/logo.png
-  capabilities: internetClient
-  build_windows: false
-  install_certificate: false
-
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
@@ -119,6 +109,12 @@ flutter:
   #   - family: Trajan Pro
   #     fonts:
   #       - asset: fonts/TrajanPro.ttf
+  #       - asset: fonts/TrajanPro_Bold.ttf
+  #         weight: 700
+  #
+  # For details regarding fonts from package dependencies,
+  # see https://flutter.dev/to/font-from-package
+ #       - asset: fonts/TrajanPro.ttf
   #       - asset: fonts/TrajanPro_Bold.ttf
   #         weight: 700
   #

--- a/flutter/windows/inno_setup.iss
+++ b/flutter/windows/inno_setup.iss
@@ -1,0 +1,35 @@
+#ifndef AppVersion
+#define AppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{DE850239-5B22-480D-B91F-3413B6B98CC4}}
+AppName=Drift
+AppVersion={#AppVersion}
+AppPublisher=Drift
+DefaultDirName={autopf}\Drift
+DefaultGroupName=Drift
+OutputDir=.\
+OutputBaseFilename=drift-windows-setup
+SetupIconFile=runner\resources\app_icon.ico
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "..\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\Drift"; Filename: "{app}\Drift.exe"
+Name: "{commondesktop}\Drift"; Filename: "{app}\Drift.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\Drift.exe"; Description: "{cm:LaunchProgram,Drift}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
This PR automates the GitHub Release process, adds versioning to all artifacts, and switches the macOS release format to a DMG installer using create-dmg. It also updates GitHub Actions to @v6 across all workflows.