### PR TITLE
fix: improve transfer error states

### DIFF
--- a/flutter/lib/shell/widgets/mobile/mobile_transfer_result_view.dart
+++ b/flutter/lib/shell/widgets/mobile/mobile_transfer_result_view.dart
@@ -21,15 +21,14 @@ class MobileTransferResultView extends ConsumerWidget {
 
     return TransferResultCard(
       fillBody: true,
-      tone: switch (result.tone) {
-        TransferResultToneData.success => TransferResultTone.success,
-        TransferResultToneData.error => TransferResultTone.error,
-      },
+      outcome: result.outcome,
       title: result.title,
       message: result.message,
       metrics: result.metrics,
       primaryLabel: result.primaryLabel,
-      onPrimary: result.primaryLabel == null ? null : notifier.resetShell,
+      onPrimary: result.primaryLabel == null
+          ? null
+          : notifier.handleTransferResultPrimaryAction,
     );
   }
 }

--- a/flutter/lib/shell/widgets/shell_state_content.dart
+++ b/flutter/lib/shell/widgets/shell_state_content.dart
@@ -72,7 +72,7 @@ class ShellStateContent extends ConsumerWidget {
         height: availableHeight,
         width: double.infinity,
         child: _buildTransferResultCard(
-          onReset: notifier.resetShell,
+          onPrimary: notifier.handleTransferResultPrimaryAction,
           result: result,
         ),
       ),
@@ -80,7 +80,7 @@ class ShellStateContent extends ConsumerWidget {
         height: availableHeight,
         width: double.infinity,
         child: _buildTransferResultCard(
-          onReset: notifier.resetShell,
+          onPrimary: notifier.handleTransferResultPrimaryAction,
           result: result,
         ),
       ),
@@ -98,7 +98,7 @@ class ShellStateContent extends ConsumerWidget {
         height: availableHeight,
         width: double.infinity,
         child: _buildTransferResultCard(
-          onReset: notifier.resetShell,
+          onPrimary: notifier.handleTransferResultPrimaryAction,
           result: result,
         ),
       ),
@@ -107,7 +107,7 @@ class ShellStateContent extends ConsumerWidget {
 }
 
 Widget _buildTransferResultCard({
-  required VoidCallback onReset,
+  required VoidCallback onPrimary,
   required TransferResultViewData? result,
 }) {
   if (result == null) {
@@ -116,14 +116,11 @@ Widget _buildTransferResultCard({
 
   return TransferResultCard(
     fillBody: true,
-    tone: switch (result.tone) {
-      TransferResultToneData.success => TransferResultTone.success,
-      TransferResultToneData.error => TransferResultTone.error,
-    },
+    outcome: result.outcome,
     title: result.title,
     message: result.message,
     metrics: result.metrics,
     primaryLabel: result.primaryLabel,
-    onPrimary: result.primaryLabel == null ? null : onReset,
+    onPrimary: result.primaryLabel == null ? null : onPrimary,
   );
 }

--- a/flutter/lib/shell/widgets/transfer_layout.dart
+++ b/flutter/lib/shell/widgets/transfer_layout.dart
@@ -14,7 +14,7 @@ class TransferFlowLayout extends StatelessWidget {
     required this.subtitle,
     this.explainer,
     required this.illustration,
-    required this.manifest,
+    this.manifest,
     required this.footer,
   });
 
@@ -24,7 +24,7 @@ class TransferFlowLayout extends StatelessWidget {
   final String subtitle;
   final Widget? explainer;
   final Widget illustration;
-  final Widget manifest;
+  final Widget? manifest;
   final Widget footer;
 
   @override
@@ -111,24 +111,25 @@ class TransferFlowLayout extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 24),
-                // Manifest Card
-                Container(
-                  decoration: BoxDecoration(
-                    color: kSurface2,
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: kBorder.withValues(alpha: 0.8)),
+                if (manifest != null) ...[
+                  Container(
+                    decoration: BoxDecoration(
+                      color: kSurface2,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(color: kBorder.withValues(alpha: 0.8)),
+                    ),
+                    child: Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(18, 16, 18, 0),
+                          child: manifest!,
+                        ),
+                        const SizedBox(height: 16),
+                      ],
+                    ),
                   ),
-                  child: Column(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.fromLTRB(18, 16, 18, 0),
-                        child: manifest,
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 24),
+                  const SizedBox(height: 24),
+                ],
               ],
             ),
           ),

--- a/flutter/lib/shell/widgets/transfer_result_card.dart
+++ b/flutter/lib/shell/widgets/transfer_result_card.dart
@@ -2,14 +2,13 @@ import 'package:flutter/material.dart';
 
 import '../../core/models/transfer_models.dart';
 import '../../core/theme/drift_theme.dart';
+import '../../state/drift_app_state.dart';
 import 'transfer_layout.dart';
-
-enum TransferResultTone { success, error }
 
 class TransferResultCard extends StatelessWidget {
   const TransferResultCard({
     super.key,
-    required this.tone,
+    required this.outcome,
     required this.title,
     required this.message,
     this.metrics,
@@ -18,7 +17,7 @@ class TransferResultCard extends StatelessWidget {
     this.fillBody = false,
   });
 
-  final TransferResultTone tone;
+  final TransferResultOutcomeData outcome;
   final String title;
   final String message;
   final List<TransferMetricRow>? metrics;
@@ -31,22 +30,27 @@ class TransferResultCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isSuccess = tone == TransferResultTone.success;
-    final accentColor = isSuccess
-        ? const Color(0xFF49B36C)
-        : const Color(0xFFCC3333);
-    final icon = isSuccess ? Icons.check_circle_rounded : Icons.error_rounded;
+    final visual = _visualForOutcome(outcome);
 
     if (fillBody) {
       return TransferFlowLayout(
-        statusLabel: isSuccess ? 'Complete' : 'Error',
-        statusColor: accentColor,
+        statusLabel: visual.statusLabel,
+        statusColor: visual.accentColor,
         title: title,
         subtitle: message,
-        illustration: Icon(icon, size: 48, color: accentColor),
+        illustration: DecoratedBox(
+          decoration: BoxDecoration(
+            color: visual.accentColor.withValues(alpha: 0.1),
+            shape: BoxShape.circle,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: Icon(visual.icon, size: 42, color: visual.accentColor),
+          ),
+        ),
         manifest: metrics != null && metrics!.isNotEmpty
             ? _TransferMetricsList(metrics: metrics!)
-            : const SizedBox.shrink(),
+            : null,
         footer: Row(
           children: [
             if (primaryLabel != null && onPrimary != null)
@@ -54,7 +58,7 @@ class TransferResultCard extends StatelessWidget {
                 child: FilledButton(
                   onPressed: onPrimary,
                   style: FilledButton.styleFrom(
-                    backgroundColor: const Color(0xFF4A8E9E),
+                    backgroundColor: visual.buttonColor,
                     foregroundColor: Colors.white,
                     minimumSize: const Size(0, 48),
                     shape: RoundedRectangleBorder(
@@ -82,7 +86,15 @@ class TransferResultCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(icon, size: 32, color: accentColor),
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: visual.accentColor.withValues(alpha: 0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(visual.icon, size: 24, color: visual.accentColor),
+          ),
           const SizedBox(height: 14),
           Text(title, style: titleStyle),
           const SizedBox(height: 4),
@@ -109,7 +121,7 @@ class TransferResultCard extends StatelessWidget {
             FilledButton(
               onPressed: onPrimary,
               style: FilledButton.styleFrom(
-                backgroundColor: const Color(0xFF4A8E9E),
+                backgroundColor: visual.buttonColor,
                 foregroundColor: Colors.white,
                 minimumSize: const Size(0, 48),
                 shape: RoundedRectangleBorder(
@@ -123,6 +135,49 @@ class TransferResultCard extends StatelessWidget {
       ),
     );
   }
+}
+
+class _TransferResultVisualData {
+  const _TransferResultVisualData({
+    required this.statusLabel,
+    required this.accentColor,
+    required this.buttonColor,
+    required this.icon,
+  });
+
+  final String statusLabel;
+  final Color accentColor;
+  final Color buttonColor;
+  final IconData icon;
+}
+
+_TransferResultVisualData _visualForOutcome(TransferResultOutcomeData outcome) {
+  return switch (outcome) {
+    TransferResultOutcomeData.success => const _TransferResultVisualData(
+      statusLabel: 'Complete',
+      accentColor: Color(0xFF49B36C),
+      buttonColor: Color(0xFF4A8E9E),
+      icon: Icons.check_circle_rounded,
+    ),
+    TransferResultOutcomeData.cancelled => const _TransferResultVisualData(
+      statusLabel: 'Cancelled',
+      accentColor: Color(0xFFC0912C),
+      buttonColor: Color(0xFF617B87),
+      icon: Icons.do_not_disturb_on_rounded,
+    ),
+    TransferResultOutcomeData.declined => const _TransferResultVisualData(
+      statusLabel: 'Declined',
+      accentColor: Color(0xFF7C8C97),
+      buttonColor: Color(0xFF4A8E9E),
+      icon: Icons.remove_circle_outline_rounded,
+    ),
+    TransferResultOutcomeData.failed => const _TransferResultVisualData(
+      statusLabel: 'Failed',
+      accentColor: Color(0xFFCC3333),
+      buttonColor: Color(0xFFB34A4A),
+      icon: Icons.error_rounded,
+    ),
+  };
 }
 
 class _TransferMetricsList extends StatelessWidget {

--- a/flutter/lib/state/drift_app_notifier.dart
+++ b/flutter/lib/state/drift_app_notifier.dart
@@ -194,6 +194,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       _setSession(
         ReceiveResultSession(
           success: true,
+          outcome: TransferResultOutcomeData.success,
           items: session.items,
           summary: session.summary.copyWith(
             statusMessage: 'Saved to ${session.summary.destinationLabel}',
@@ -219,6 +220,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     final session = state.session;
     if (session is ReceiveOfferSession && session.decisionPending) {
       unawaited(_respondToIncomingOffer(accept: false));
+      return;
     }
     resetShell();
   }
@@ -260,6 +262,24 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _clearSendMetricState();
     _clearReceiveMetricState();
     _setSession(const IdleSession());
+  }
+
+  void handleTransferResultPrimaryAction() {
+    final result = state.transferResult;
+    if (result == null) {
+      return;
+    }
+
+    switch (result.primaryAction) {
+      case TransferResultPrimaryActionData.done:
+      case null:
+        resetShell();
+      case TransferResultPrimaryActionData.tryAgain:
+      case TransferResultPrimaryActionData.sendAgain:
+        _restoreSendDraft(destinationCode: state.sendDestinationCode);
+      case TransferResultPrimaryActionData.chooseAnotherDevice:
+        _returnToSendSelection();
+    }
   }
 
   void goBack() {
@@ -512,7 +532,9 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           onError: (Object error, StackTrace stackTrace) {
             debugPrint('watchIncomingTransfers failed: $error');
             debugPrintStack(stackTrace: stackTrace);
-            resetShell();
+            _applyIncomingFailure(
+              errorMessage: 'Drift lost the connection while receiving files.',
+            );
           },
         );
   }
@@ -538,10 +560,10 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           '[drift/notifier] incoming receive failed: '
           '${event.errorMessage ?? event.statusMessage}',
         );
-        resetShell();
+        _applyIncomingFailed(event);
         return;
       case rust_receiver.ReceiverTransferPhase.declined:
-        resetShell();
+        _applyIncomingDeclined(event);
         return;
     }
   }
@@ -642,6 +664,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _setSession(
       ReceiveResultSession(
         success: true,
+        outcome: TransferResultOutcomeData.success,
         items: state.receiveItems,
         summary: completedSummary,
         metrics: _buildReceiveCompletionMetrics(
@@ -681,6 +704,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _setSession(
       ReceiveResultSession(
         success: false,
+        outcome: TransferResultOutcomeData.cancelled,
         items: state.receiveItems,
         summary: summary.copyWith(
           destinationLabel: event.saveRootLabel,
@@ -691,6 +715,117 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         payloadBytesReceived: bytesReceived,
         payloadTotalBytes: totalBytes,
         senderDeviceType: event.senderDeviceType,
+      ),
+    );
+    _clearReceiveMetricState();
+  }
+
+  void _applyIncomingFailed(rust_receiver.ReceiverTransferEvent event) {
+    _applyIncomingFailure(
+      errorMessage: event.errorMessage ?? event.statusMessage,
+      event: event,
+    );
+  }
+
+  void _applyIncomingDeclined(rust_receiver.ReceiverTransferEvent event) {
+    final summary =
+        state.receiveSummary ??
+        TransferSummaryViewData(
+          itemCount: _bigIntToInt(event.itemCount),
+          totalSize: event.totalSizeLabel,
+          code: state.idleReceiveCode,
+          expiresAt: '',
+          destinationLabel: event.saveRootLabel.isNotEmpty
+              ? event.saveRootLabel
+              : 'Downloads',
+          statusMessage: event.errorMessage ?? event.statusMessage,
+          senderName: event.senderName,
+        );
+
+    _setSession(
+      ReceiveResultSession(
+        success: false,
+        outcome: TransferResultOutcomeData.declined,
+        items: state.receiveItems,
+        summary: summary.copyWith(
+          destinationLabel: event.saveRootLabel.isNotEmpty
+              ? event.saveRootLabel
+              : summary.destinationLabel,
+          statusMessage: event.errorMessage ?? event.statusMessage,
+          senderName: event.senderName.isNotEmpty
+              ? event.senderName
+              : summary.senderName,
+        ),
+        plan: event.plan ?? state.receiveTransferPlan,
+        snapshot: event.snapshot ?? state.receiveTransferSnapshot,
+        payloadBytesReceived: state.receivePayloadBytesReceived,
+        payloadTotalBytes:
+            state.receivePayloadTotalBytes ??
+            _bigIntToInt(event.totalSizeBytes),
+        senderDeviceType: event.senderDeviceType,
+      ),
+    );
+    _clearReceiveMetricState();
+  }
+
+  void _applyIncomingFailure({
+    required String errorMessage,
+    rust_receiver.ReceiverTransferEvent? event,
+  }) {
+    final progress = _progressFromSnapshot(
+      event?.snapshot ?? state.receiveTransferSnapshot,
+    );
+    final bytesReceived =
+        progress.bytesTransferred ??
+        (event == null
+            ? state.receivePayloadBytesReceived
+            : _bigIntToInt(event.bytesReceived)) ??
+        0;
+    final totalBytes =
+        progress.totalBytes ??
+        (event == null
+            ? state.receivePayloadTotalBytes
+            : _bigIntToInt(event.totalSizeBytes));
+    if (_receivePayloadStartedAt == null && bytesReceived > 0) {
+      _receivePayloadStartedAt = DateTime.now();
+    }
+
+    final summary =
+        state.receiveSummary ??
+        TransferSummaryViewData(
+          itemCount: event == null
+              ? state.receiveItems.length
+              : _bigIntToInt(event.itemCount),
+          totalSize: event?.totalSizeLabel ?? '',
+          code: state.idleReceiveCode,
+          expiresAt: '',
+          destinationLabel: event?.saveRootLabel ?? state.downloadRoot,
+          statusMessage: errorMessage,
+          senderName: event?.senderName ?? '',
+        );
+
+    _setSession(
+      ReceiveResultSession(
+        success: false,
+        outcome: TransferResultOutcomeData.failed,
+        items: state.receiveItems,
+        summary: summary.copyWith(
+          itemCount: event == null
+              ? summary.itemCount
+              : _bigIntToInt(event.itemCount),
+          totalSize: event?.totalSizeLabel ?? summary.totalSize,
+          destinationLabel: event?.saveRootLabel.isNotEmpty == true
+              ? event!.saveRootLabel
+              : summary.destinationLabel,
+          statusMessage: errorMessage,
+          senderName: event?.senderName ?? summary.senderName,
+        ),
+        plan: event?.plan ?? state.receiveTransferPlan,
+        snapshot: event?.snapshot ?? state.receiveTransferSnapshot,
+        payloadBytesReceived: bytesReceived,
+        payloadTotalBytes: totalBytes,
+        senderDeviceType:
+            event?.senderDeviceType ?? state.receiveSenderDeviceType,
       ),
     );
     _clearReceiveMetricState();
@@ -718,7 +853,11 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     } catch (error, stackTrace) {
       debugPrint('respondToOffer failed: $error');
       debugPrintStack(stackTrace: stackTrace);
-      resetShell();
+      _applyIncomingFailure(
+        errorMessage: accept
+            ? 'Drift couldn\'t accept the transfer.'
+            : 'Drift couldn\'t decline the transfer.',
+      );
     }
   }
 
@@ -738,11 +877,17 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     } catch (error, stackTrace) {
       debugPrint('cancelReceiveTransfer failed: $error');
       debugPrintStack(stackTrace: stackTrace);
-      resetShell();
+      _applyIncomingFailure(
+        errorMessage: 'Drift couldn\'t cancel the transfer.',
+      );
     }
   }
 
   void _returnToSendSelection() {
+    _restoreSendDraft();
+  }
+
+  void _restoreSendDraft({String destinationCode = ''}) {
     _cancelActiveSendTransfer();
     _clearSendMetricState();
     _setSession(
@@ -752,7 +897,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         nearbyDestinations: const [],
         nearbyScanInFlight: false,
         nearbyScanCompletedOnce: false,
-        destinationCode: '',
+        destinationCode: destinationCode,
       ),
     );
     _scheduleNearbyScanning();
@@ -961,6 +1106,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: false,
+            outcome: TransferResultOutcomeData.declined,
             items: items,
             summary: summary.copyWith(
               statusMessage: update.errorMessage ?? 'Transfer declined.',
@@ -993,6 +1139,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: true,
+            outcome: TransferResultOutcomeData.success,
             items: items,
             summary: summary,
             metrics: _buildSendCompletionMetrics(
@@ -1008,6 +1155,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: false,
+            outcome: TransferResultOutcomeData.cancelled,
             items: items,
             summary: summary.copyWith(
               statusMessage: update.errorMessage ?? 'Transfer cancelled.',
@@ -1021,6 +1169,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: false,
+            outcome: TransferResultOutcomeData.failed,
             items: items,
             summary: summary,
             plan: update.plan ?? state.sendTransferPlan,

--- a/flutter/lib/state/drift_app_state.dart
+++ b/flutter/lib/state/drift_app_state.dart
@@ -6,23 +6,41 @@ import '../src/rust/api/transfer.dart' as rust_transfer;
 import 'app_identity.dart';
 import 'receiver_service_source.dart';
 
-enum TransferResultToneData { success, error }
+enum TransferResultOutcomeData { success, cancelled, declined, failed }
+
+enum TransferResultPrimaryActionData {
+  done,
+  tryAgain,
+  chooseAnotherDevice,
+  sendAgain,
+}
 
 @immutable
 class TransferResultViewData {
   const TransferResultViewData({
-    required this.tone,
+    required this.outcome,
     required this.title,
     required this.message,
     this.metrics,
-    this.primaryLabel,
+    this.primaryAction,
+    this.secondaryLabel,
   });
 
-  final TransferResultToneData tone;
+  final TransferResultOutcomeData outcome;
   final String title;
   final String message;
   final List<TransferMetricRow>? metrics;
-  final String? primaryLabel;
+  final TransferResultPrimaryActionData? primaryAction;
+  final String? secondaryLabel;
+
+  String? get primaryLabel => switch (primaryAction) {
+    TransferResultPrimaryActionData.done => 'Done',
+    TransferResultPrimaryActionData.tryAgain => 'Try again',
+    TransferResultPrimaryActionData.chooseAnotherDevice =>
+      'Choose another device',
+    TransferResultPrimaryActionData.sendAgain => 'Send again',
+    null => null,
+  };
 }
 
 @immutable
@@ -290,29 +308,17 @@ class DriftAppState {
   };
 
   TransferResultViewData? get transferResult => switch (session) {
-    SendResultSession(:final success, :final summary, :final metrics) =>
-      TransferResultViewData(
-        tone: success
-            ? TransferResultToneData.success
-            : TransferResultToneData.error,
-        title: success
-            ? 'Transfer complete'
-            : _isCancelledMessage(summary.statusMessage)
-            ? 'Transfer cancelled'
-            : 'Transfer failed',
-        message: summary.statusMessage,
-        metrics: success ? metrics : null,
-        primaryLabel: success ? 'Done' : null,
+    SendResultSession(:final outcome, :final summary, :final metrics) =>
+      _buildSendTransferResultViewData(
+        outcome: outcome,
+        summary: summary,
+        metrics: metrics,
       ),
-    ReceiveResultSession(:final success, :final summary, :final metrics) =>
-      TransferResultViewData(
-        tone: success
-            ? TransferResultToneData.success
-            : TransferResultToneData.error,
-        title: success ? 'Files saved' : 'Transfer cancelled',
-        message: summary.statusMessage,
-        metrics: success ? metrics : null,
-        primaryLabel: 'Done',
+    ReceiveResultSession(:final outcome, :final summary, :final metrics) =>
+      _buildReceiveTransferResultViewData(
+        outcome: outcome,
+        summary: summary,
+        metrics: metrics,
       ),
     _ => null,
   };
@@ -422,8 +428,111 @@ String _formatBytes(int bytes) {
   return '$formatted ${units[unitIndex]}';
 }
 
-bool _isCancelledMessage(String message) =>
-    message.toLowerCase().contains('cancel');
+TransferResultViewData _buildSendTransferResultViewData({
+  required TransferResultOutcomeData outcome,
+  required TransferSummaryViewData summary,
+  required List<TransferMetricRow>? metrics,
+}) {
+  return switch (outcome) {
+    TransferResultOutcomeData.success => TransferResultViewData(
+      outcome: outcome,
+      title: 'Transfer complete',
+      message: summary.statusMessage,
+      metrics: metrics,
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.cancelled => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.cancelled,
+      title: 'Transfer cancelled',
+      message: 'The transfer was stopped before all files were sent.',
+      primaryAction: TransferResultPrimaryActionData.sendAgain,
+    ),
+    TransferResultOutcomeData.declined => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.declined,
+      title: 'Transfer declined',
+      message: 'The receiving device chose not to accept this transfer.',
+      primaryAction: TransferResultPrimaryActionData.chooseAnotherDevice,
+    ),
+    TransferResultOutcomeData.failed => TransferResultViewData(
+      outcome: outcome,
+      title: 'Transfer failed',
+      message: _sendFailureMessage(summary.statusMessage),
+      primaryAction: TransferResultPrimaryActionData.tryAgain,
+    ),
+  };
+}
+
+TransferResultViewData _buildReceiveTransferResultViewData({
+  required TransferResultOutcomeData outcome,
+  required TransferSummaryViewData summary,
+  required List<TransferMetricRow>? metrics,
+}) {
+  return switch (outcome) {
+    TransferResultOutcomeData.success => TransferResultViewData(
+      outcome: outcome,
+      title: 'Files saved',
+      message: summary.statusMessage,
+      metrics: metrics,
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.cancelled => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.cancelled,
+      title: 'Receive cancelled',
+      message: 'Drift stopped receiving before all files were saved.',
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.declined => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.declined,
+      title: 'Transfer declined',
+      message: 'The transfer was declined before any files were received.',
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.failed => TransferResultViewData(
+      outcome: outcome,
+      title: 'Couldn\'t finish receiving files',
+      message: _receiveFailureMessage(summary.statusMessage),
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+  };
+}
+
+String _sendFailureMessage(String rawMessage) {
+  if (_isHumanReadableTransferMessage(rawMessage)) {
+    return rawMessage;
+  }
+  return 'Drift couldn\'t finish sending the files. Try again.';
+}
+
+String _receiveFailureMessage(String rawMessage) {
+  if (_isHumanReadableTransferMessage(rawMessage)) {
+    return rawMessage;
+  }
+  return 'Drift couldn\'t save all incoming files successfully.';
+}
+
+bool _isHumanReadableTransferMessage(String message) {
+  final trimmed = message.trim();
+  if (trimmed.isEmpty) {
+    return false;
+  }
+  if (trimmed.contains('\n')) {
+    return false;
+  }
+  if (trimmed.length > 140) {
+    return false;
+  }
+
+  const noisyFragments = <String>[
+    'Exception',
+    'StackTrace',
+    'socketexception',
+    'typeerror',
+  ];
+  final lower = trimmed.toLowerCase();
+  return !noisyFragments.any(
+    (fragment) => lower.contains(fragment.toLowerCase()),
+  );
+}
 
 sealed class ShellSessionState {
   const ShellSessionState();
@@ -557,6 +666,7 @@ class SendTransferSession extends ShellSessionState {
 class SendResultSession extends TransferResultSession {
   const SendResultSession({
     required this.success,
+    required this.outcome,
     required super.items,
     required super.summary,
     super.metrics,
@@ -566,6 +676,7 @@ class SendResultSession extends TransferResultSession {
   }) : super();
 
   final bool success;
+  final TransferResultOutcomeData outcome;
   final String? remoteDeviceType;
 }
 
@@ -640,6 +751,7 @@ class ReceiveTransferSession extends ShellSessionState {
 class ReceiveResultSession extends TransferResultSession {
   const ReceiveResultSession({
     required this.success,
+    required this.outcome,
     required super.items,
     required super.summary,
     super.metrics,
@@ -651,6 +763,7 @@ class ReceiveResultSession extends TransferResultSession {
   }) : super();
 
   final bool success;
+  final TransferResultOutcomeData outcome;
   final int? payloadBytesReceived;
   final int? payloadTotalBytes;
   final String? senderDeviceType;

--- a/flutter/test/state/drift_app_notifier_test.dart
+++ b/flutter/test/state/drift_app_notifier_test.dart
@@ -214,9 +214,13 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
       status: 'Ready',
       phase: ReceiverBadgePhase.ready,
     ),
+    this.respondError,
+    this.cancelError,
   });
 
   final ReceiverBadgeState initialBadge;
+  final Object? respondError;
+  final Object? cancelError;
   final List<bool> discoverableCalls = <bool>[];
   final List<bool> respondToOfferCalls = <bool>[];
   final StreamController<ReceiverBadgeState> badgeController =
@@ -227,11 +231,18 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
 
   @override
   Future<void> respondToOffer({required bool accept}) async {
+    if (respondError != null) {
+      throw respondError!;
+    }
     respondToOfferCalls.add(accept);
   }
 
   @override
-  Future<void> cancelTransfer() async {}
+  Future<void> cancelTransfer() async {
+    if (cancelError != null) {
+      throw cancelError!;
+    }
+  }
 
   @override
   Future<void> setDiscoverable({required bool enabled}) async {
@@ -309,6 +320,42 @@ rust_receiver.ReceiverTransferEvent _incomingReceivingEvent({
     itemCount: BigInt.one,
     totalSizeBytes: BigInt.from(18 * 1024),
     bytesReceived: receivedBytes,
+    totalSizeLabel: '18 KB',
+    files: const [],
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
+  required BigInt receivedBytes,
+  String errorMessage = 'Drift lost the connection while receiving files.',
+}) {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.failed,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer failed.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: receivedBytes,
+    totalSizeLabel: '18 KB',
+    files: const [],
+    errorMessage: errorMessage,
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingDeclinedEvent() {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.declined,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer declined.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: BigInt.zero,
     totalSizeLabel: '18 KB',
     files: const [],
   );
@@ -689,6 +736,85 @@ void main() {
   });
 
   testWidgets(
+    'send result actions preserve selection and clear device choice when needed',
+    (tester) async {
+      final receiverService = FakeReceiverServiceSource();
+      final sendTransferSource = FakeSendTransferSource();
+      final container = _buildContainer(
+        receiverServiceSource: receiverService,
+        sendTransferSource: sendTransferSource,
+      );
+      addTearDown(sendTransferSource.dispose);
+      addTearDown(receiverService.dispose);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(driftAppNotifierProvider.notifier);
+      await _flushAsyncWork(tester);
+
+      notifier.pickSendItems();
+      await _flushAsyncWork(tester);
+      notifier.updateSendDestinationCode('ab2cd3');
+      await _flushAsyncWork(tester);
+      notifier.startSend();
+      await _flushAsyncWork(tester);
+
+      sendTransferSource.controller.add(
+        _sendUpdate(
+          phase: SendTransferUpdatePhase.failed,
+          statusMessage: 'receiver disconnected unexpectedly',
+        ),
+      );
+      await _flushAsyncWork(tester);
+
+      final failedState = container.read(driftAppNotifierProvider);
+      expect(
+        failedState.transferResult?.outcome,
+        TransferResultOutcomeData.failed,
+      );
+      expect(
+        failedState.transferResult?.primaryAction,
+        TransferResultPrimaryActionData.tryAgain,
+      );
+
+      notifier.handleTransferResultPrimaryAction();
+      await _flushAsyncWork(tester);
+
+      final retryState = container.read(driftAppNotifierProvider);
+      expect(retryState.session, isA<SendDraftSession>());
+      expect(retryState.sendItems, _sampleSendItems);
+      expect(retryState.sendDestinationCode, 'AB2CD3');
+
+      notifier.startSend();
+      await _flushAsyncWork(tester);
+      sendTransferSource.controller.add(
+        _sendUpdate(phase: SendTransferUpdatePhase.declined),
+      );
+      await _flushAsyncWork(tester);
+
+      final declinedState = container.read(driftAppNotifierProvider);
+      expect(
+        declinedState.transferResult?.outcome,
+        TransferResultOutcomeData.declined,
+      );
+      expect(
+        declinedState.transferResult?.primaryAction,
+        TransferResultPrimaryActionData.chooseAnotherDevice,
+      );
+
+      notifier.handleTransferResultPrimaryAction();
+      await _flushAsyncWork(tester);
+
+      final chooseAnotherState = container.read(driftAppNotifierProvider);
+      expect(chooseAnotherState.session, isA<SendDraftSession>());
+      expect(chooseAnotherState.sendItems, _sampleSendItems);
+      expect(chooseAnotherState.sendDestinationCode, isEmpty);
+
+      notifier.resetShell();
+      await _flushAsyncWork(tester);
+    },
+  );
+
+  testWidgets(
     'incoming offers move to review and accept/decline use receiver service',
     (tester) async {
       final receiverService = FakeReceiverServiceSource();
@@ -729,11 +855,144 @@ void main() {
       await _flushAsyncWork(tester);
       container.read(driftAppNotifierProvider.notifier).declineReceiveOffer();
       await _flushAsyncWork(tester);
+      receiverService.incomingController.add(_incomingDeclinedEvent());
+      await _flushAsyncWork(tester);
       expect(
         container.read(driftAppNotifierProvider).session,
-        isA<IdleSession>(),
+        isA<ReceiveResultSession>(),
       );
       expect(receiverService.respondToOfferCalls.last, isFalse);
     },
   );
+
+  testWidgets('incoming receive failure stays on a terminal error state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    container.read(driftAppNotifierProvider.notifier).acceptReceiveOffer();
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(
+      _incomingReceivingEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(
+      _incomingFailedEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift lost the connection while receiving files.',
+    );
+    expect(state.receivePayloadBytesReceived, 9 * 1024);
+  });
+
+  testWidgets('incoming declined stays on a terminal declined state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    receiverService.incomingController.add(_incomingDeclinedEvent());
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.declined);
+    expect(state.transferResult?.title, 'Transfer declined');
+  });
+
+  testWidgets('respond to offer failure stays visible as a receive error', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource(
+      respondError: Exception('backend unavailable'),
+    );
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    container.read(driftAppNotifierProvider.notifier).acceptReceiveOffer();
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift couldn\'t accept the transfer.',
+    );
+  });
+
+  testWidgets('receive cancel failure stays visible as a receive error', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource(
+      cancelError: Exception('cancel failed'),
+    );
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    container.read(driftAppNotifierProvider.notifier).acceptReceiveOffer();
+    await _flushAsyncWork(tester);
+    receiverService.incomingController.add(
+      _incomingReceivingEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await _flushAsyncWork(tester);
+
+    container.read(driftAppNotifierProvider.notifier).cancelReceiveInProgress();
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift couldn\'t cancel the transfer.',
+    );
+  });
 }

--- a/flutter/test/widget_test.dart
+++ b/flutter/test/widget_test.dart
@@ -325,9 +325,13 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
       status: 'Ready',
       phase: ReceiverBadgePhase.ready,
     ),
+    this.respondError,
+    this.cancelError,
   });
 
   final ReceiverBadgeState initialBadge;
+  final Object? respondError;
+  final Object? cancelError;
   final StreamController<ReceiverBadgeState> _badgeController =
       StreamController<ReceiverBadgeState>.broadcast();
   final StreamController<rust_receiver.ReceiverTransferEvent>
@@ -337,7 +341,11 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
   final List<bool> respondToOfferCalls = <bool>[];
 
   @override
-  Future<void> cancelTransfer() async {}
+  Future<void> cancelTransfer() async {
+    if (cancelError != null) {
+      throw cancelError!;
+    }
+  }
 
   void emitBadge(ReceiverBadgeState badge) {
     _badgeController.add(badge);
@@ -354,6 +362,9 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
 
   @override
   Future<void> respondToOffer({required bool accept}) async {
+    if (respondError != null) {
+      throw respondError!;
+    }
     respondToOfferCalls.add(accept);
   }
 
@@ -394,6 +405,42 @@ rust_receiver.ReceiverTransferEvent _incomingOfferEvent() {
         size: BigInt.from(18 * 1024),
       ),
     ],
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
+  required BigInt receivedBytes,
+  String errorMessage = 'Drift lost the connection while receiving files.',
+}) {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.failed,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer failed.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: receivedBytes,
+    totalSizeLabel: '18 KB',
+    files: const [],
+    errorMessage: errorMessage,
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingDeclinedEvent() {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.declined,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer declined.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: BigInt.zero,
+    totalSizeLabel: '18 KB',
+    files: const [],
   );
 }
 
@@ -569,7 +616,14 @@ void main() {
     await tester.tap(find.text('Decline'));
     await pumpUiSettled(tester);
 
-    expect(find.text('Tap to choose files to send.'), findsOneWidget);
+    receiverService.emitIncoming(_incomingDeclinedEvent());
+    await pumpUiSettled(tester);
+
+    expect(find.text('Transfer declined'), findsOneWidget);
+    expect(
+      find.text('The transfer was declined before any files were received.'),
+      findsOneWidget,
+    );
     expectNoFlutterError(tester);
   });
 
@@ -615,6 +669,63 @@ void main() {
 
     expect(find.text('Tap to choose files to send.'), findsOneWidget);
     expectNoFlutterError(tester);
+  });
+
+  testWidgets('mobile receive failure stays on a transfer error state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = buildTestContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    await pumpMobileShell(tester, container: container);
+
+    receiverService.emitIncoming(_incomingOfferEvent());
+    await pumpUiSettled(tester);
+    await tester.tap(saveToDownloadsButton());
+    await pumpUiSettled(tester);
+
+    receiverService.emitIncoming(
+      _incomingFailedEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await pumpUiSettled(tester);
+
+    expect(find.text('Couldn\'t finish receiving files'), findsOneWidget);
+    expect(
+      find.text('Drift lost the connection while receiving files.'),
+      findsOneWidget,
+    );
+    expect(find.text('Done'), findsOneWidget);
+
+    await tester.tap(find.text('Done'));
+    await pumpUiSettled(tester);
+
+    expect(find.text('Tap to choose files to send.'), findsOneWidget);
+    expectNoFlutterError(tester);
+  });
+
+  testWidgets('mobile receive declined stays on a terminal declined state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = buildTestContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    await pumpMobileShell(tester, container: container);
+
+    receiverService.emitIncoming(_incomingOfferEvent());
+    await pumpUiSettled(tester);
+    receiverService.emitIncoming(_incomingDeclinedEvent());
+    await pumpUiSettled(tester);
+
+    expect(find.text('Transfer declined'), findsOneWidget);
+    expect(
+      find.text('The transfer was declined before any files were received.'),
+      findsOneWidget,
+    );
+    expect(find.text('Done'), findsOneWidget);
   });
 
   testWidgets('after drop state routes straight to manual code entry', (
@@ -809,7 +920,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Transfer cancelled'), findsOneWidget);
-    expect(find.text('Transfer cancelled.'), findsOneWidget);
+    expect(
+      find.text('The transfer was stopped before all files were sent.'),
+      findsOneWidget,
+    );
+    expect(find.text('Send again'), findsOneWidget);
+
+    await tester.tap(find.text('Send again'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Send with code'), findsOneWidget);
+    expect(find.text('sample.txt'), findsWidgets);
     container.read(driftAppNotifierProvider.notifier).resetShell();
     await tester.pumpAndSettle();
     expectNoFlutterError(tester);
@@ -883,60 +1004,60 @@ void main() {
     expectNoFlutterError(tester);
   });
 
-  testWidgets(
-    'send failure shows the rust error and back returns to selection',
-    (tester) async {
-      final sendTransferSource = FakeSendTransferSource();
-      final container = buildTestContainer(
-        sendTransferSource: sendTransferSource,
-      );
-      await pumpUtilityApp(tester, container: container);
+  testWidgets('send failure shows retry action and preserves selection', (
+    tester,
+  ) async {
+    final sendTransferSource = FakeSendTransferSource();
+    final container = buildTestContainer(
+      sendTransferSource: sendTransferSource,
+    );
+    await pumpUtilityApp(tester, container: container);
 
-      await tester.tap(chooseFilesButton());
-      await tester.pumpAndSettle();
-      await tester.enterText(sendCodeField(), 'ab2cd3');
-      await tester.pump();
+    await tester.tap(chooseFilesButton());
+    await tester.pumpAndSettle();
+    await tester.enterText(sendCodeField(), 'ab2cd3');
+    await tester.pump();
 
-      await tester.tap(find.text('Send'));
-      await tester.pump();
+    await tester.tap(find.text('Send'));
+    await tester.pump();
 
-      sendTransferSource.emit(
-        sendTransferUpdate(
-          phase: SendTransferUpdatePhase.connecting,
-          destinationLabel: 'Code AB2 CD3',
-          statusMessage: 'Request sent',
-        ),
-      );
-      await tester.pumpAndSettle();
+    sendTransferSource.emit(
+      sendTransferUpdate(
+        phase: SendTransferUpdatePhase.connecting,
+        destinationLabel: 'Code AB2 CD3',
+        statusMessage: 'Request sent',
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      sendTransferSource.emit(
-        sendTransferUpdate(
-          phase: SendTransferUpdatePhase.failed,
-          destinationLabel: 'Code AB2 CD3',
-          statusMessage: 'Request sent',
-          errorMessage:
-              'receiver declined the offer: receiver declined the offer',
-        ),
-      );
-      await sendTransferSource.finish();
-      await tester.pumpAndSettle();
+    sendTransferSource.emit(
+      sendTransferUpdate(
+        phase: SendTransferUpdatePhase.failed,
+        destinationLabel: 'Code AB2 CD3',
+        statusMessage: 'Request sent',
+        errorMessage:
+            'receiver declined the offer: receiver declined the offer',
+      ),
+    );
+    await sendTransferSource.finish();
+    await tester.pumpAndSettle();
 
-      expect(find.text('Transfer failed'), findsOneWidget);
-      expect(
-        find.text('receiver declined the offer: receiver declined the offer'),
-        findsOneWidget,
-      );
+    expect(find.text('Transfer failed'), findsOneWidget);
+    expect(
+      find.text('receiver declined the offer: receiver declined the offer'),
+      findsOneWidget,
+    );
+    expect(find.text('Try again'), findsOneWidget);
 
-      await tester.tap(shellBackButton());
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
 
-      expect(find.text('Send with code'), findsOneWidget);
-      expect(find.text('sample.txt'), findsWidgets);
-      container.read(driftAppNotifierProvider.notifier).resetShell();
-      await tester.pumpAndSettle();
-      expectNoFlutterError(tester);
-    },
-  );
+    expect(find.text('Send with code'), findsOneWidget);
+    expect(find.text('sample.txt'), findsWidgets);
+    container.read(driftAppNotifierProvider.notifier).resetShell();
+    await tester.pumpAndSettle();
+    expectNoFlutterError(tester);
+  });
 
   testWidgets('recipient fallback avoids raw unknown device labels', (
     tester,


### PR DESCRIPTION
## Summary
- add differentiated terminal transfer result states across send and receive
- keep receiver failures and declines visible instead of resetting back to idle
- surface accept/decline/cancel receive-action failures as terminal error states

## Testing
- flutter test test/state/drift_app_notifier_test.dart
- flutter test test/widget_test.dart