### PR TITLE
fix: improve transfer error states

### DIFF
--- a/flutter/lib/shell/widgets/mobile/mobile_transfer_result_view.dart
+++ b/flutter/lib/shell/widgets/mobile/mobile_transfer_result_view.dart
@@ -21,15 +21,14 @@ class MobileTransferResultView extends ConsumerWidget {
 
     return TransferResultCard(
       fillBody: true,
-      tone: switch (result.tone) {
-        TransferResultToneData.success => TransferResultTone.success,
-        TransferResultToneData.error => TransferResultTone.error,
-      },
+      outcome: result.outcome,
       title: result.title,
       message: result.message,
       metrics: result.metrics,
       primaryLabel: result.primaryLabel,
-      onPrimary: result.primaryLabel == null ? null : notifier.resetShell,
+      onPrimary: result.primaryLabel == null
+          ? null
+          : notifier.handleTransferResultPrimaryAction,
     );
   }
 }

--- a/flutter/lib/shell/widgets/mobile/mobile_transfer_result_view.dart
+++ b/flutter/lib/shell/widgets/mobile/mobile_transfer_result_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../state/drift_app_state.dart';
 import '../../../state/drift_providers.dart';
 import '../transfer_result_card.dart';
 

--- a/flutter/lib/shell/widgets/send_drop_panel.dart
+++ b/flutter/lib/shell/widgets/send_drop_panel.dart
@@ -9,11 +9,13 @@ class SendDropPanel extends StatefulWidget {
     required this.onChooseFiles,
     required this.onDropPaths,
     required this.height,
+    this.errorMessage,
   });
 
   final VoidCallback onChooseFiles;
   final ValueChanged<List<String>> onDropPaths;
   final double height;
+  final String? errorMessage;
 
   @override
   State<SendDropPanel> createState() => _SendDropPanelState();
@@ -63,6 +65,10 @@ class _SendDropPanelState extends State<SendDropPanel> {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
+                  if (widget.errorMessage?.trim().isNotEmpty == true) ...[
+                    _SendSetupErrorBanner(message: widget.errorMessage!),
+                    const SizedBox(height: 18),
+                  ],
                   Center(
                     child: AnimatedContainer(
                       duration: const Duration(milliseconds: 180),
@@ -129,6 +135,51 @@ class _SendDropPanelState extends State<SendDropPanel> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _SendSetupErrorBanner extends StatelessWidget {
+  const _SendSetupErrorBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFCC3333).withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: const Color(0xFFCC3333).withValues(alpha: 0.2),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 1),
+            child: Icon(
+              Icons.error_outline_rounded,
+              size: 18,
+              color: Color(0xFFCC3333),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: driftSans(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w500,
+                color: kInk,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/flutter/lib/shell/widgets/send_selected_card.dart
+++ b/flutter/lib/shell/widgets/send_selected_card.dart
@@ -50,6 +50,13 @@ class _SendSelectedCardState extends ConsumerState<SendSelectedCard> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
+                      if (state.sendSetupErrorMessage?.trim().isNotEmpty ==
+                          true) ...[
+                        _SendSetupErrorBanner(
+                          message: state.sendSetupErrorMessage!,
+                        ),
+                        const SizedBox(height: 16),
+                      ],
                       const SelectedItemsSection(),
                       const SizedBox(height: 24),
                       const NearbyDevicesSection(),
@@ -136,6 +143,51 @@ class _SendSelectedCardState extends ConsumerState<SendSelectedCard> {
                     ],
                   ),
                 ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SendSetupErrorBanner extends StatelessWidget {
+  const _SendSetupErrorBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: const Color(0xFFCC3333).withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: const Color(0xFFCC3333).withValues(alpha: 0.18),
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.only(top: 1),
+            child: Icon(
+              Icons.error_outline_rounded,
+              size: 18,
+              color: Color(0xFFCC3333),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              message,
+              style: driftSans(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w500,
+                color: kInk,
+                height: 1.35,
               ),
             ),
           ),

--- a/flutter/lib/shell/widgets/shell_state_content.dart
+++ b/flutter/lib/shell/widgets/shell_state_content.dart
@@ -43,6 +43,7 @@ class ShellStateContent extends ConsumerWidget {
         onChooseFiles: notifier.pickSendItems,
         onDropPaths: notifier.acceptDroppedSendItems,
         height: availableHeight,
+        errorMessage: state.sendSetupErrorMessage,
       ),
       ShellView.sendSelected => SizedBox(
         height: availableHeight,

--- a/flutter/lib/shell/widgets/shell_state_content.dart
+++ b/flutter/lib/shell/widgets/shell_state_content.dart
@@ -72,7 +72,7 @@ class ShellStateContent extends ConsumerWidget {
         height: availableHeight,
         width: double.infinity,
         child: _buildTransferResultCard(
-          onReset: notifier.resetShell,
+          onPrimary: notifier.handleTransferResultPrimaryAction,
           result: result,
         ),
       ),
@@ -80,7 +80,7 @@ class ShellStateContent extends ConsumerWidget {
         height: availableHeight,
         width: double.infinity,
         child: _buildTransferResultCard(
-          onReset: notifier.resetShell,
+          onPrimary: notifier.handleTransferResultPrimaryAction,
           result: result,
         ),
       ),
@@ -98,7 +98,7 @@ class ShellStateContent extends ConsumerWidget {
         height: availableHeight,
         width: double.infinity,
         child: _buildTransferResultCard(
-          onReset: notifier.resetShell,
+          onPrimary: notifier.handleTransferResultPrimaryAction,
           result: result,
         ),
       ),
@@ -107,7 +107,7 @@ class ShellStateContent extends ConsumerWidget {
 }
 
 Widget _buildTransferResultCard({
-  required VoidCallback onReset,
+  required VoidCallback onPrimary,
   required TransferResultViewData? result,
 }) {
   if (result == null) {
@@ -116,14 +116,11 @@ Widget _buildTransferResultCard({
 
   return TransferResultCard(
     fillBody: true,
-    tone: switch (result.tone) {
-      TransferResultToneData.success => TransferResultTone.success,
-      TransferResultToneData.error => TransferResultTone.error,
-    },
+    outcome: result.outcome,
     title: result.title,
     message: result.message,
     metrics: result.metrics,
     primaryLabel: result.primaryLabel,
-    onPrimary: result.primaryLabel == null ? null : onReset,
+    onPrimary: result.primaryLabel == null ? null : onPrimary,
   );
 }

--- a/flutter/lib/shell/widgets/transfer_layout.dart
+++ b/flutter/lib/shell/widgets/transfer_layout.dart
@@ -14,7 +14,7 @@ class TransferFlowLayout extends StatelessWidget {
     required this.subtitle,
     this.explainer,
     required this.illustration,
-    required this.manifest,
+    this.manifest,
     required this.footer,
   });
 
@@ -24,7 +24,7 @@ class TransferFlowLayout extends StatelessWidget {
   final String subtitle;
   final Widget? explainer;
   final Widget illustration;
-  final Widget manifest;
+  final Widget? manifest;
   final Widget footer;
 
   @override
@@ -111,24 +111,25 @@ class TransferFlowLayout extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 24),
-                // Manifest Card
-                Container(
-                  decoration: BoxDecoration(
-                    color: kSurface2,
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: kBorder.withValues(alpha: 0.8)),
+                if (manifest != null) ...[
+                  Container(
+                    decoration: BoxDecoration(
+                      color: kSurface2,
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(color: kBorder.withValues(alpha: 0.8)),
+                    ),
+                    child: Column(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(18, 16, 18, 0),
+                          child: manifest!,
+                        ),
+                        const SizedBox(height: 16),
+                      ],
+                    ),
                   ),
-                  child: Column(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.fromLTRB(18, 16, 18, 0),
-                        child: manifest,
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 24),
+                  const SizedBox(height: 24),
+                ],
               ],
             ),
           ),

--- a/flutter/lib/shell/widgets/transfer_result_card.dart
+++ b/flutter/lib/shell/widgets/transfer_result_card.dart
@@ -2,14 +2,13 @@ import 'package:flutter/material.dart';
 
 import '../../core/models/transfer_models.dart';
 import '../../core/theme/drift_theme.dart';
+import '../../state/drift_app_state.dart';
 import 'transfer_layout.dart';
-
-enum TransferResultTone { success, error }
 
 class TransferResultCard extends StatelessWidget {
   const TransferResultCard({
     super.key,
-    required this.tone,
+    required this.outcome,
     required this.title,
     required this.message,
     this.metrics,
@@ -18,7 +17,7 @@ class TransferResultCard extends StatelessWidget {
     this.fillBody = false,
   });
 
-  final TransferResultTone tone;
+  final TransferResultOutcomeData outcome;
   final String title;
   final String message;
   final List<TransferMetricRow>? metrics;
@@ -31,22 +30,27 @@ class TransferResultCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isSuccess = tone == TransferResultTone.success;
-    final accentColor = isSuccess
-        ? const Color(0xFF49B36C)
-        : const Color(0xFFCC3333);
-    final icon = isSuccess ? Icons.check_circle_rounded : Icons.error_rounded;
+    final visual = _visualForOutcome(outcome);
 
     if (fillBody) {
       return TransferFlowLayout(
-        statusLabel: isSuccess ? 'Complete' : 'Error',
-        statusColor: accentColor,
+        statusLabel: visual.statusLabel,
+        statusColor: visual.accentColor,
         title: title,
         subtitle: message,
-        illustration: Icon(icon, size: 48, color: accentColor),
+        illustration: DecoratedBox(
+          decoration: BoxDecoration(
+            color: visual.accentColor.withValues(alpha: 0.1),
+            shape: BoxShape.circle,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: Icon(visual.icon, size: 42, color: visual.accentColor),
+          ),
+        ),
         manifest: metrics != null && metrics!.isNotEmpty
             ? _TransferMetricsList(metrics: metrics!)
-            : const SizedBox.shrink(),
+            : null,
         footer: Row(
           children: [
             if (primaryLabel != null && onPrimary != null)
@@ -54,7 +58,7 @@ class TransferResultCard extends StatelessWidget {
                 child: FilledButton(
                   onPressed: onPrimary,
                   style: FilledButton.styleFrom(
-                    backgroundColor: const Color(0xFF4A8E9E),
+                    backgroundColor: visual.buttonColor,
                     foregroundColor: Colors.white,
                     minimumSize: const Size(0, 48),
                     shape: RoundedRectangleBorder(
@@ -82,7 +86,15 @@ class TransferResultCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(icon, size: 32, color: accentColor),
+          Container(
+            width: 44,
+            height: 44,
+            decoration: BoxDecoration(
+              color: visual.accentColor.withValues(alpha: 0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(visual.icon, size: 24, color: visual.accentColor),
+          ),
           const SizedBox(height: 14),
           Text(title, style: titleStyle),
           const SizedBox(height: 4),
@@ -109,7 +121,7 @@ class TransferResultCard extends StatelessWidget {
             FilledButton(
               onPressed: onPrimary,
               style: FilledButton.styleFrom(
-                backgroundColor: const Color(0xFF4A8E9E),
+                backgroundColor: visual.buttonColor,
                 foregroundColor: Colors.white,
                 minimumSize: const Size(0, 48),
                 shape: RoundedRectangleBorder(
@@ -123,6 +135,49 @@ class TransferResultCard extends StatelessWidget {
       ),
     );
   }
+}
+
+class _TransferResultVisualData {
+  const _TransferResultVisualData({
+    required this.statusLabel,
+    required this.accentColor,
+    required this.buttonColor,
+    required this.icon,
+  });
+
+  final String statusLabel;
+  final Color accentColor;
+  final Color buttonColor;
+  final IconData icon;
+}
+
+_TransferResultVisualData _visualForOutcome(TransferResultOutcomeData outcome) {
+  return switch (outcome) {
+    TransferResultOutcomeData.success => const _TransferResultVisualData(
+      statusLabel: 'Complete',
+      accentColor: Color(0xFF49B36C),
+      buttonColor: Color(0xFF4A8E9E),
+      icon: Icons.check_circle_rounded,
+    ),
+    TransferResultOutcomeData.cancelled => const _TransferResultVisualData(
+      statusLabel: 'Cancelled',
+      accentColor: Color(0xFFC0912C),
+      buttonColor: Color(0xFF617B87),
+      icon: Icons.do_not_disturb_on_rounded,
+    ),
+    TransferResultOutcomeData.declined => const _TransferResultVisualData(
+      statusLabel: 'Declined',
+      accentColor: Color(0xFF7C8C97),
+      buttonColor: Color(0xFF4A8E9E),
+      icon: Icons.remove_circle_outline_rounded,
+    ),
+    TransferResultOutcomeData.failed => const _TransferResultVisualData(
+      statusLabel: 'Failed',
+      accentColor: Color(0xFFCC3333),
+      buttonColor: Color(0xFFB34A4A),
+      icon: Icons.error_rounded,
+    ),
+  };
 }
 
 class _TransferMetricsList extends StatelessWidget {

--- a/flutter/lib/state/drift_app_notifier.dart
+++ b/flutter/lib/state/drift_app_notifier.dart
@@ -74,6 +74,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       receiverBadge: const ReceiverBadgeState.registering(),
       session: const IdleSession(),
       animateSendingConnection: _animateSendingConnection,
+      sendSetupErrorMessage: null,
     );
   }
 
@@ -261,6 +262,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _cancelActiveSendTransfer();
     _clearSendMetricState();
     _clearReceiveMetricState();
+    state = state.copyWith(clearSendSetupErrorMessage: true);
     _setSession(const IdleSession());
   }
 
@@ -327,11 +329,16 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       if (items.isEmpty) {
         return;
       }
+      _clearSendSetupError();
       _beginSendInspection(clearExistingItems: true);
       _applySelectedSendItems(items);
     } catch (error, stackTrace) {
       clearSendFlow();
-      _reportSendSelectionError(error, stackTrace);
+      _reportSendSelectionError(
+        'Drift couldn\'t prepare the selected files.',
+        error,
+        stackTrace,
+      );
     }
   }
 
@@ -346,10 +353,15 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         clearSendFlow();
         return;
       }
+      _clearSendSetupError();
       _applySelectedSendItems(items);
     } catch (error, stackTrace) {
       clearSendFlow();
-      _reportSendSelectionError(error, stackTrace);
+      _reportSendSelectionError(
+        'Drift couldn\'t prepare the dropped files.',
+        error,
+        stackTrace,
+      );
     }
   }
 
@@ -368,10 +380,15 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _finishSendInspection();
         return;
       }
+      _clearSendSetupError();
       _applySelectedSendItems(items);
     } catch (error, stackTrace) {
       _finishSendInspection();
-      _reportSendSelectionError(error, stackTrace);
+      _reportSendSelectionError(
+        'Drift couldn\'t add those files right now.',
+        error,
+        stackTrace,
+      );
     }
   }
 
@@ -391,10 +408,15 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _finishSendInspection();
         return;
       }
+      _clearSendSetupError();
       _applySelectedSendItems(items);
     } catch (error, stackTrace) {
       _finishSendInspection();
-      _reportSendSelectionError(error, stackTrace);
+      _reportSendSelectionError(
+        'Drift couldn\'t add those files right now.',
+        error,
+        stackTrace,
+      );
     }
   }
 
@@ -413,15 +435,21 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         clearSendFlow();
         return;
       }
+      _clearSendSetupError();
       _applySelectedSendItems(items);
     } catch (error, stackTrace) {
       _finishSendInspection();
-      _reportSendSelectionError(error, stackTrace);
+      _reportSendSelectionError(
+        'Drift couldn\'t update the selected files.',
+        error,
+        stackTrace,
+      );
     }
   }
 
   void _applySelectedSendItems(List<TransferItemViewData> items) {
     _cancelActiveSendTransfer();
+    state = state.copyWith(clearSendSetupErrorMessage: true);
     _setSession(
       SendDraftSession(
         items: List<TransferItemViewData>.unmodifiable(items),
@@ -722,7 +750,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
 
   void _applyIncomingFailed(rust_receiver.ReceiverTransferEvent event) {
     _applyIncomingFailure(
-      errorMessage: event.errorMessage ?? event.statusMessage,
+      errorMessage: event.error?.message ?? event.statusMessage,
       event: event,
     );
   }
@@ -738,7 +766,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           destinationLabel: event.saveRootLabel.isNotEmpty
               ? event.saveRootLabel
               : 'Downloads',
-          statusMessage: event.errorMessage ?? event.statusMessage,
+          statusMessage: event.error?.message ?? event.statusMessage,
           senderName: event.senderName,
         );
 
@@ -751,7 +779,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           destinationLabel: event.saveRootLabel.isNotEmpty
               ? event.saveRootLabel
               : summary.destinationLabel,
-          statusMessage: event.errorMessage ?? event.statusMessage,
+          statusMessage: event.error?.message ?? event.statusMessage,
           senderName: event.senderName.isNotEmpty
               ? event.senderName
               : summary.senderName,
@@ -867,7 +895,21 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     } catch (error, stackTrace) {
       debugPrint('cancelTransfer failed: $error');
       debugPrintStack(stackTrace: stackTrace);
-      _returnToSendSelection();
+      _applySendUpdate(
+        SendTransferUpdate(
+          phase: SendTransferUpdatePhase.failed,
+          destinationLabel:
+              state.sendDestinationLabel ??
+              _formatCodeAsDestination(state.sendDestinationCode),
+          statusMessage: 'Cancelling transfer...',
+          itemCount: state.sendItems.length,
+          totalSize:
+              state.sendSummary?.totalSize ?? sampleSendSummary.totalSize,
+          bytesSent: state.sendPayloadBytesSent ?? 0,
+          totalBytes: state.sendPayloadTotalBytes ?? 0,
+          errorMessage: 'Drift couldn\'t cancel the transfer.',
+        ),
+      );
     }
   }
 
@@ -947,6 +989,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     } catch (error, stackTrace) {
       debugPrint('[drift/notifier] nearby scan failed: $error');
       debugPrintStack(stackTrace: stackTrace);
+      _setSendSetupError('Drift couldn\'t scan for nearby devices right now.');
       final current = _draftSession;
       if (current != null) {
         _setSession(
@@ -1328,9 +1371,22 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
   List<String> get _currentSendSelectionPaths =>
       state.sendItems.map((item) => item.path).toList(growable: false);
 
-  void _reportSendSelectionError(Object error, StackTrace stackTrace) {
+  void _reportSendSelectionError(
+    String userMessage,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    _setSendSetupError(userMessage);
     debugPrint('Failed to inspect selected send items: $error');
     debugPrintStack(stackTrace: stackTrace);
+  }
+
+  void _setSendSetupError(String message) {
+    state = state.copyWith(sendSetupErrorMessage: message);
+  }
+
+  void _clearSendSetupError() {
+    state = state.copyWith(clearSendSetupErrorMessage: true);
   }
 
   void _clearSendMetricState() {

--- a/flutter/lib/state/drift_app_notifier.dart
+++ b/flutter/lib/state/drift_app_notifier.dart
@@ -194,6 +194,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
       _setSession(
         ReceiveResultSession(
           success: true,
+          outcome: TransferResultOutcomeData.success,
           items: session.items,
           summary: session.summary.copyWith(
             statusMessage: 'Saved to ${session.summary.destinationLabel}',
@@ -219,6 +220,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     final session = state.session;
     if (session is ReceiveOfferSession && session.decisionPending) {
       unawaited(_respondToIncomingOffer(accept: false));
+      return;
     }
     resetShell();
   }
@@ -260,6 +262,24 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _clearSendMetricState();
     _clearReceiveMetricState();
     _setSession(const IdleSession());
+  }
+
+  void handleTransferResultPrimaryAction() {
+    final result = state.transferResult;
+    if (result == null) {
+      return;
+    }
+
+    switch (result.primaryAction) {
+      case TransferResultPrimaryActionData.done:
+      case null:
+        resetShell();
+      case TransferResultPrimaryActionData.tryAgain:
+      case TransferResultPrimaryActionData.sendAgain:
+        _restoreSendDraft(destinationCode: state.sendDestinationCode);
+      case TransferResultPrimaryActionData.chooseAnotherDevice:
+        _returnToSendSelection();
+    }
   }
 
   void goBack() {
@@ -512,7 +532,9 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           onError: (Object error, StackTrace stackTrace) {
             debugPrint('watchIncomingTransfers failed: $error');
             debugPrintStack(stackTrace: stackTrace);
-            resetShell();
+            _applyIncomingFailure(
+              errorMessage: 'Drift lost the connection while receiving files.',
+            );
           },
         );
   }
@@ -538,10 +560,10 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
           '[drift/notifier] incoming receive failed: '
           '${event.error?.message ?? event.statusMessage}',
         );
-        resetShell();
+        _applyIncomingFailed(event);
         return;
       case rust_receiver.ReceiverTransferPhase.declined:
-        resetShell();
+        _applyIncomingDeclined(event);
         return;
     }
   }
@@ -642,6 +664,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _setSession(
       ReceiveResultSession(
         success: true,
+        outcome: TransferResultOutcomeData.success,
         items: state.receiveItems,
         summary: completedSummary,
         metrics: _buildReceiveCompletionMetrics(
@@ -681,6 +704,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     _setSession(
       ReceiveResultSession(
         success: false,
+        outcome: TransferResultOutcomeData.cancelled,
         items: state.receiveItems,
         summary: summary.copyWith(
           destinationLabel: event.saveRootLabel,
@@ -691,6 +715,117 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         payloadBytesReceived: bytesReceived,
         payloadTotalBytes: totalBytes,
         senderDeviceType: event.senderDeviceType,
+      ),
+    );
+    _clearReceiveMetricState();
+  }
+
+  void _applyIncomingFailed(rust_receiver.ReceiverTransferEvent event) {
+    _applyIncomingFailure(
+      errorMessage: event.errorMessage ?? event.statusMessage,
+      event: event,
+    );
+  }
+
+  void _applyIncomingDeclined(rust_receiver.ReceiverTransferEvent event) {
+    final summary =
+        state.receiveSummary ??
+        TransferSummaryViewData(
+          itemCount: _bigIntToInt(event.itemCount),
+          totalSize: event.totalSizeLabel,
+          code: state.idleReceiveCode,
+          expiresAt: '',
+          destinationLabel: event.saveRootLabel.isNotEmpty
+              ? event.saveRootLabel
+              : 'Downloads',
+          statusMessage: event.errorMessage ?? event.statusMessage,
+          senderName: event.senderName,
+        );
+
+    _setSession(
+      ReceiveResultSession(
+        success: false,
+        outcome: TransferResultOutcomeData.declined,
+        items: state.receiveItems,
+        summary: summary.copyWith(
+          destinationLabel: event.saveRootLabel.isNotEmpty
+              ? event.saveRootLabel
+              : summary.destinationLabel,
+          statusMessage: event.errorMessage ?? event.statusMessage,
+          senderName: event.senderName.isNotEmpty
+              ? event.senderName
+              : summary.senderName,
+        ),
+        plan: event.plan ?? state.receiveTransferPlan,
+        snapshot: event.snapshot ?? state.receiveTransferSnapshot,
+        payloadBytesReceived: state.receivePayloadBytesReceived,
+        payloadTotalBytes:
+            state.receivePayloadTotalBytes ??
+            _bigIntToInt(event.totalSizeBytes),
+        senderDeviceType: event.senderDeviceType,
+      ),
+    );
+    _clearReceiveMetricState();
+  }
+
+  void _applyIncomingFailure({
+    required String errorMessage,
+    rust_receiver.ReceiverTransferEvent? event,
+  }) {
+    final progress = _progressFromSnapshot(
+      event?.snapshot ?? state.receiveTransferSnapshot,
+    );
+    final bytesReceived =
+        progress.bytesTransferred ??
+        (event == null
+            ? state.receivePayloadBytesReceived
+            : _bigIntToInt(event.bytesReceived)) ??
+        0;
+    final totalBytes =
+        progress.totalBytes ??
+        (event == null
+            ? state.receivePayloadTotalBytes
+            : _bigIntToInt(event.totalSizeBytes));
+    if (_receivePayloadStartedAt == null && bytesReceived > 0) {
+      _receivePayloadStartedAt = DateTime.now();
+    }
+
+    final summary =
+        state.receiveSummary ??
+        TransferSummaryViewData(
+          itemCount: event == null
+              ? state.receiveItems.length
+              : _bigIntToInt(event.itemCount),
+          totalSize: event?.totalSizeLabel ?? '',
+          code: state.idleReceiveCode,
+          expiresAt: '',
+          destinationLabel: event?.saveRootLabel ?? state.downloadRoot,
+          statusMessage: errorMessage,
+          senderName: event?.senderName ?? '',
+        );
+
+    _setSession(
+      ReceiveResultSession(
+        success: false,
+        outcome: TransferResultOutcomeData.failed,
+        items: state.receiveItems,
+        summary: summary.copyWith(
+          itemCount: event == null
+              ? summary.itemCount
+              : _bigIntToInt(event.itemCount),
+          totalSize: event?.totalSizeLabel ?? summary.totalSize,
+          destinationLabel: event?.saveRootLabel.isNotEmpty == true
+              ? event!.saveRootLabel
+              : summary.destinationLabel,
+          statusMessage: errorMessage,
+          senderName: event?.senderName ?? summary.senderName,
+        ),
+        plan: event?.plan ?? state.receiveTransferPlan,
+        snapshot: event?.snapshot ?? state.receiveTransferSnapshot,
+        payloadBytesReceived: bytesReceived,
+        payloadTotalBytes: totalBytes,
+        senderDeviceType:
+            event?.senderDeviceType ?? state.receiveSenderDeviceType,
       ),
     );
     _clearReceiveMetricState();
@@ -718,7 +853,11 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     } catch (error, stackTrace) {
       debugPrint('respondToOffer failed: $error');
       debugPrintStack(stackTrace: stackTrace);
-      resetShell();
+      _applyIncomingFailure(
+        errorMessage: accept
+            ? 'Drift couldn\'t accept the transfer.'
+            : 'Drift couldn\'t decline the transfer.',
+      );
     }
   }
 
@@ -738,11 +877,17 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
     } catch (error, stackTrace) {
       debugPrint('cancelReceiveTransfer failed: $error');
       debugPrintStack(stackTrace: stackTrace);
-      resetShell();
+      _applyIncomingFailure(
+        errorMessage: 'Drift couldn\'t cancel the transfer.',
+      );
     }
   }
 
   void _returnToSendSelection() {
+    _restoreSendDraft();
+  }
+
+  void _restoreSendDraft({String destinationCode = ''}) {
     _cancelActiveSendTransfer();
     _clearSendMetricState();
     _setSession(
@@ -752,7 +897,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         nearbyDestinations: const [],
         nearbyScanInFlight: false,
         nearbyScanCompletedOnce: false,
-        destinationCode: '',
+        destinationCode: destinationCode,
       ),
     );
     _scheduleNearbyScanning();
@@ -961,6 +1106,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: false,
+            outcome: TransferResultOutcomeData.declined,
             items: items,
             summary: summary.copyWith(
               statusMessage: update.errorMessage ?? 'Transfer declined.',
@@ -993,6 +1139,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: true,
+            outcome: TransferResultOutcomeData.success,
             items: items,
             summary: summary,
             metrics: _buildSendCompletionMetrics(
@@ -1008,6 +1155,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: false,
+            outcome: TransferResultOutcomeData.cancelled,
             items: items,
             summary: summary.copyWith(
               statusMessage: update.errorMessage ?? 'Transfer cancelled.',
@@ -1021,6 +1169,7 @@ class DriftAppNotifier extends Notifier<DriftAppState> {
         _setSession(
           SendResultSession(
             success: false,
+            outcome: TransferResultOutcomeData.failed,
             items: items,
             summary: summary,
             plan: update.plan ?? state.sendTransferPlan,

--- a/flutter/lib/state/drift_app_state.dart
+++ b/flutter/lib/state/drift_app_state.dart
@@ -6,23 +6,41 @@ import '../src/rust/api/transfer.dart' as rust_transfer;
 import 'app_identity.dart';
 import 'receiver_service_source.dart';
 
-enum TransferResultToneData { success, error }
+enum TransferResultOutcomeData { success, cancelled, declined, failed }
+
+enum TransferResultPrimaryActionData {
+  done,
+  tryAgain,
+  chooseAnotherDevice,
+  sendAgain,
+}
 
 @immutable
 class TransferResultViewData {
   const TransferResultViewData({
-    required this.tone,
+    required this.outcome,
     required this.title,
     required this.message,
     this.metrics,
-    this.primaryLabel,
+    this.primaryAction,
+    this.secondaryLabel,
   });
 
-  final TransferResultToneData tone;
+  final TransferResultOutcomeData outcome;
   final String title;
   final String message;
   final List<TransferMetricRow>? metrics;
-  final String? primaryLabel;
+  final TransferResultPrimaryActionData? primaryAction;
+  final String? secondaryLabel;
+
+  String? get primaryLabel => switch (primaryAction) {
+    TransferResultPrimaryActionData.done => 'Done',
+    TransferResultPrimaryActionData.tryAgain => 'Try again',
+    TransferResultPrimaryActionData.chooseAnotherDevice =>
+      'Choose another device',
+    TransferResultPrimaryActionData.sendAgain => 'Send again',
+    null => null,
+  };
 }
 
 @immutable
@@ -290,29 +308,17 @@ class DriftAppState {
   };
 
   TransferResultViewData? get transferResult => switch (session) {
-    SendResultSession(:final success, :final summary, :final metrics) =>
-      TransferResultViewData(
-        tone: success
-            ? TransferResultToneData.success
-            : TransferResultToneData.error,
-        title: success
-            ? 'Transfer complete'
-            : _isCancelledMessage(summary.statusMessage)
-            ? 'Transfer cancelled'
-            : 'Transfer failed',
-        message: summary.statusMessage,
-        metrics: success ? metrics : null,
-        primaryLabel: success ? 'Done' : null,
+    SendResultSession(:final outcome, :final summary, :final metrics) =>
+      _buildSendTransferResultViewData(
+        outcome: outcome,
+        summary: summary,
+        metrics: metrics,
       ),
-    ReceiveResultSession(:final success, :final summary, :final metrics) =>
-      TransferResultViewData(
-        tone: success
-            ? TransferResultToneData.success
-            : TransferResultToneData.error,
-        title: success ? 'Files saved' : 'Transfer cancelled',
-        message: summary.statusMessage,
-        metrics: success ? metrics : null,
-        primaryLabel: 'Done',
+    ReceiveResultSession(:final outcome, :final summary, :final metrics) =>
+      _buildReceiveTransferResultViewData(
+        outcome: outcome,
+        summary: summary,
+        metrics: metrics,
       ),
     _ => null,
   };
@@ -422,8 +428,111 @@ String _formatBytes(int bytes) {
   return '$formatted ${units[unitIndex]}';
 }
 
-bool _isCancelledMessage(String message) =>
-    message.toLowerCase().contains('cancel');
+TransferResultViewData _buildSendTransferResultViewData({
+  required TransferResultOutcomeData outcome,
+  required TransferSummaryViewData summary,
+  required List<TransferMetricRow>? metrics,
+}) {
+  return switch (outcome) {
+    TransferResultOutcomeData.success => TransferResultViewData(
+      outcome: outcome,
+      title: 'Transfer complete',
+      message: summary.statusMessage,
+      metrics: metrics,
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.cancelled => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.cancelled,
+      title: 'Transfer cancelled',
+      message: 'The transfer was stopped before all files were sent.',
+      primaryAction: TransferResultPrimaryActionData.sendAgain,
+    ),
+    TransferResultOutcomeData.declined => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.declined,
+      title: 'Transfer declined',
+      message: 'The receiving device chose not to accept this transfer.',
+      primaryAction: TransferResultPrimaryActionData.chooseAnotherDevice,
+    ),
+    TransferResultOutcomeData.failed => TransferResultViewData(
+      outcome: outcome,
+      title: 'Transfer failed',
+      message: _sendFailureMessage(summary.statusMessage),
+      primaryAction: TransferResultPrimaryActionData.tryAgain,
+    ),
+  };
+}
+
+TransferResultViewData _buildReceiveTransferResultViewData({
+  required TransferResultOutcomeData outcome,
+  required TransferSummaryViewData summary,
+  required List<TransferMetricRow>? metrics,
+}) {
+  return switch (outcome) {
+    TransferResultOutcomeData.success => TransferResultViewData(
+      outcome: outcome,
+      title: 'Files saved',
+      message: summary.statusMessage,
+      metrics: metrics,
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.cancelled => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.cancelled,
+      title: 'Receive cancelled',
+      message: 'Drift stopped receiving before all files were saved.',
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.declined => const TransferResultViewData(
+      outcome: TransferResultOutcomeData.declined,
+      title: 'Transfer declined',
+      message: 'The transfer was declined before any files were received.',
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+    TransferResultOutcomeData.failed => TransferResultViewData(
+      outcome: outcome,
+      title: 'Couldn\'t finish receiving files',
+      message: _receiveFailureMessage(summary.statusMessage),
+      primaryAction: TransferResultPrimaryActionData.done,
+    ),
+  };
+}
+
+String _sendFailureMessage(String rawMessage) {
+  if (_isHumanReadableTransferMessage(rawMessage)) {
+    return rawMessage;
+  }
+  return 'Drift couldn\'t finish sending the files. Try again.';
+}
+
+String _receiveFailureMessage(String rawMessage) {
+  if (_isHumanReadableTransferMessage(rawMessage)) {
+    return rawMessage;
+  }
+  return 'Drift couldn\'t save all incoming files successfully.';
+}
+
+bool _isHumanReadableTransferMessage(String message) {
+  final trimmed = message.trim();
+  if (trimmed.isEmpty) {
+    return false;
+  }
+  if (trimmed.contains('\n')) {
+    return false;
+  }
+  if (trimmed.length > 140) {
+    return false;
+  }
+
+  const noisyFragments = <String>[
+    'Exception',
+    'StackTrace',
+    'socketexception',
+    'typeerror',
+  ];
+  final lower = trimmed.toLowerCase();
+  return !noisyFragments.any(
+    (fragment) => lower.contains(fragment.toLowerCase()),
+  );
+}
 
 sealed class ShellSessionState {
   const ShellSessionState();
@@ -557,6 +666,7 @@ class SendTransferSession extends ShellSessionState {
 class SendResultSession extends TransferResultSession {
   const SendResultSession({
     required this.success,
+    required this.outcome,
     required super.items,
     required super.summary,
     super.metrics,
@@ -566,6 +676,7 @@ class SendResultSession extends TransferResultSession {
   }) : super();
 
   final bool success;
+  final TransferResultOutcomeData outcome;
   final String? remoteDeviceType;
 }
 
@@ -640,6 +751,7 @@ class ReceiveTransferSession extends ShellSessionState {
 class ReceiveResultSession extends TransferResultSession {
   const ReceiveResultSession({
     required this.success,
+    required this.outcome,
     required super.items,
     required super.summary,
     super.metrics,
@@ -651,6 +763,7 @@ class ReceiveResultSession extends TransferResultSession {
   }) : super();
 
   final bool success;
+  final TransferResultOutcomeData outcome;
   final int? payloadBytesReceived;
   final int? payloadTotalBytes;
   final String? senderDeviceType;

--- a/flutter/lib/state/drift_app_state.dart
+++ b/flutter/lib/state/drift_app_state.dart
@@ -50,18 +50,22 @@ class DriftAppState {
     required this.receiverBadge,
     required this.session,
     required this.animateSendingConnection,
+    this.sendSetupErrorMessage,
   });
 
   final DriftAppIdentity identity;
   final ReceiverBadgeState receiverBadge;
   final ShellSessionState session;
   final bool animateSendingConnection;
+  final String? sendSetupErrorMessage;
 
   DriftAppState copyWith({
     DriftAppIdentity? identity,
     ReceiverBadgeState? receiverBadge,
     ShellSessionState? session,
     bool? animateSendingConnection,
+    String? sendSetupErrorMessage,
+    bool clearSendSetupErrorMessage = false,
   }) {
     return DriftAppState(
       identity: identity ?? this.identity,
@@ -69,6 +73,9 @@ class DriftAppState {
       session: session ?? this.session,
       animateSendingConnection:
           animateSendingConnection ?? this.animateSendingConnection,
+      sendSetupErrorMessage: clearSendSetupErrorMessage
+          ? null
+          : (sendSetupErrorMessage ?? this.sendSetupErrorMessage),
     );
   }
 

--- a/flutter/test/state/drift_app_notifier_test.dart
+++ b/flutter/test/state/drift_app_notifier_test.dart
@@ -214,9 +214,13 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
       status: 'Ready',
       phase: ReceiverBadgePhase.ready,
     ),
+    this.respondError,
+    this.cancelError,
   });
 
   final ReceiverBadgeState initialBadge;
+  final Object? respondError;
+  final Object? cancelError;
   final List<bool> discoverableCalls = <bool>[];
   final List<bool> respondToOfferCalls = <bool>[];
   final StreamController<ReceiverBadgeState> badgeController =
@@ -227,11 +231,18 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
 
   @override
   Future<void> respondToOffer({required bool accept}) async {
+    if (respondError != null) {
+      throw respondError!;
+    }
     respondToOfferCalls.add(accept);
   }
 
   @override
-  Future<void> cancelTransfer() async {}
+  Future<void> cancelTransfer() async {
+    if (cancelError != null) {
+      throw cancelError!;
+    }
+  }
 
   @override
   Future<void> setDiscoverable({required bool enabled}) async {
@@ -309,6 +320,42 @@ rust_receiver.ReceiverTransferEvent _incomingReceivingEvent({
     itemCount: BigInt.one,
     totalSizeBytes: BigInt.from(18 * 1024),
     bytesReceived: receivedBytes,
+    totalSizeLabel: '18 KB',
+    files: const [],
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
+  required BigInt receivedBytes,
+  String errorMessage = 'Drift lost the connection while receiving files.',
+}) {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.failed,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer failed.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: receivedBytes,
+    totalSizeLabel: '18 KB',
+    files: const [],
+    errorMessage: errorMessage,
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingDeclinedEvent() {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.declined,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer declined.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: BigInt.zero,
     totalSizeLabel: '18 KB',
     files: const [],
   );
@@ -689,6 +736,85 @@ void main() {
   });
 
   testWidgets(
+    'send result actions preserve selection and clear device choice when needed',
+    (tester) async {
+      final receiverService = FakeReceiverServiceSource();
+      final sendTransferSource = FakeSendTransferSource();
+      final container = _buildContainer(
+        receiverServiceSource: receiverService,
+        sendTransferSource: sendTransferSource,
+      );
+      addTearDown(sendTransferSource.dispose);
+      addTearDown(receiverService.dispose);
+      addTearDown(container.dispose);
+
+      final notifier = container.read(driftAppNotifierProvider.notifier);
+      await _flushAsyncWork(tester);
+
+      notifier.pickSendItems();
+      await _flushAsyncWork(tester);
+      notifier.updateSendDestinationCode('ab2cd3');
+      await _flushAsyncWork(tester);
+      notifier.startSend();
+      await _flushAsyncWork(tester);
+
+      sendTransferSource.controller.add(
+        _sendUpdate(
+          phase: SendTransferUpdatePhase.failed,
+          statusMessage: 'receiver disconnected unexpectedly',
+        ),
+      );
+      await _flushAsyncWork(tester);
+
+      final failedState = container.read(driftAppNotifierProvider);
+      expect(
+        failedState.transferResult?.outcome,
+        TransferResultOutcomeData.failed,
+      );
+      expect(
+        failedState.transferResult?.primaryAction,
+        TransferResultPrimaryActionData.tryAgain,
+      );
+
+      notifier.handleTransferResultPrimaryAction();
+      await _flushAsyncWork(tester);
+
+      final retryState = container.read(driftAppNotifierProvider);
+      expect(retryState.session, isA<SendDraftSession>());
+      expect(retryState.sendItems, _sampleSendItems);
+      expect(retryState.sendDestinationCode, 'AB2CD3');
+
+      notifier.startSend();
+      await _flushAsyncWork(tester);
+      sendTransferSource.controller.add(
+        _sendUpdate(phase: SendTransferUpdatePhase.declined),
+      );
+      await _flushAsyncWork(tester);
+
+      final declinedState = container.read(driftAppNotifierProvider);
+      expect(
+        declinedState.transferResult?.outcome,
+        TransferResultOutcomeData.declined,
+      );
+      expect(
+        declinedState.transferResult?.primaryAction,
+        TransferResultPrimaryActionData.chooseAnotherDevice,
+      );
+
+      notifier.handleTransferResultPrimaryAction();
+      await _flushAsyncWork(tester);
+
+      final chooseAnotherState = container.read(driftAppNotifierProvider);
+      expect(chooseAnotherState.session, isA<SendDraftSession>());
+      expect(chooseAnotherState.sendItems, _sampleSendItems);
+      expect(chooseAnotherState.sendDestinationCode, isEmpty);
+
+      notifier.resetShell();
+      await _flushAsyncWork(tester);
+    },
+  );
+
+  testWidgets(
     'incoming offers move to review and accept/decline use receiver service',
     (tester) async {
       final receiverService = FakeReceiverServiceSource();
@@ -729,11 +855,144 @@ void main() {
       await _flushAsyncWork(tester);
       container.read(driftAppNotifierProvider.notifier).declineReceiveOffer();
       await _flushAsyncWork(tester);
+      receiverService.incomingController.add(_incomingDeclinedEvent());
+      await _flushAsyncWork(tester);
       expect(
         container.read(driftAppNotifierProvider).session,
-        isA<IdleSession>(),
+        isA<ReceiveResultSession>(),
       );
       expect(receiverService.respondToOfferCalls.last, isFalse);
     },
   );
+
+  testWidgets('incoming receive failure stays on a terminal error state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    container.read(driftAppNotifierProvider.notifier).acceptReceiveOffer();
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(
+      _incomingReceivingEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(
+      _incomingFailedEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift lost the connection while receiving files.',
+    );
+    expect(state.receivePayloadBytesReceived, 9 * 1024);
+  });
+
+  testWidgets('incoming declined stays on a terminal declined state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    receiverService.incomingController.add(_incomingDeclinedEvent());
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.declined);
+    expect(state.transferResult?.title, 'Transfer declined');
+  });
+
+  testWidgets('respond to offer failure stays visible as a receive error', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource(
+      respondError: Exception('backend unavailable'),
+    );
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    container.read(driftAppNotifierProvider.notifier).acceptReceiveOffer();
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift couldn\'t accept the transfer.',
+    );
+  });
+
+  testWidgets('receive cancel failure stays visible as a receive error', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource(
+      cancelError: Exception('cancel failed'),
+    );
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    receiverService.incomingController.add(_incomingOfferEvent());
+    await _flushAsyncWork(tester);
+    container.read(driftAppNotifierProvider.notifier).acceptReceiveOffer();
+    await _flushAsyncWork(tester);
+    receiverService.incomingController.add(
+      _incomingReceivingEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await _flushAsyncWork(tester);
+
+    container.read(driftAppNotifierProvider.notifier).cancelReceiveInProgress();
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<ReceiveResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift couldn\'t cancel the transfer.',
+    );
+  });
 }

--- a/flutter/test/state/drift_app_notifier_test.dart
+++ b/flutter/test/state/drift_app_notifier_test.dart
@@ -9,6 +9,7 @@ import 'package:drift_app/state/drift_providers.dart';
 import 'package:drift_app/state/nearby_discovery_source.dart';
 import 'package:drift_app/state/receiver_service_source.dart';
 import 'package:drift_app/state/settings_store.dart';
+import 'package:drift_app/src/rust/api/error.dart' as rust_error;
 import 'package:drift_app/src/rust/api/receiver.dart' as rust_receiver;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -85,6 +86,7 @@ class FakeSendItemSource implements SendItemSource {
     List<List<String>>? pickResponses,
     Map<String, TransferItemViewData>? itemCatalog,
     this.appendPathsHandler,
+    this.pickFilesError,
   }) : _pickResponses =
            pickResponses ??
            const [
@@ -101,6 +103,7 @@ class FakeSendItemSource implements SendItemSource {
     required List<String> incomingPaths,
   })?
   appendPathsHandler;
+  final Object? pickFilesError;
   int _pickIndex = 0;
 
   @override
@@ -142,8 +145,9 @@ class FakeSendItemSource implements SendItemSource {
       _mapPaths(paths);
 
   @override
-  Future<List<TransferItemViewData>> pickFiles() async =>
-      _mapPaths(_nextPickResponse());
+  Future<List<TransferItemViewData>> pickFiles() async => pickFilesError == null
+      ? _mapPaths(_nextPickResponse())
+      : Future<List<TransferItemViewData>>.error(pickFilesError!);
 
   @override
   Future<List<TransferItemViewData>> removePath({
@@ -174,9 +178,12 @@ class FakeSendItemSource implements SendItemSource {
 }
 
 class FakeSendTransferSource implements SendTransferSource {
+  FakeSendTransferSource({this.cancelError});
+
   SendTransferRequestData? lastRequest;
   final StreamController<SendTransferUpdate> controller =
       StreamController<SendTransferUpdate>.broadcast();
+  final Object? cancelError;
 
   @override
   Stream<SendTransferUpdate> startTransfer(SendTransferRequestData request) {
@@ -185,7 +192,11 @@ class FakeSendTransferSource implements SendTransferSource {
   }
 
   @override
-  Future<void> cancelTransfer() async {}
+  Future<void> cancelTransfer() async {
+    if (cancelError != null) {
+      throw cancelError!;
+    }
+  }
 
   Future<void> dispose() async {
     await controller.close();
@@ -322,12 +333,18 @@ rust_receiver.ReceiverTransferEvent _incomingReceivingEvent({
     bytesReceived: receivedBytes,
     totalSizeLabel: '18 KB',
     files: const [],
+    error: const rust_error.UserFacingErrorData(
+      kind: rust_error.UserFacingErrorKindData.connectionLost,
+      title: 'Connection lost',
+      message: 'Drift lost the connection while receiving files.',
+      recovery: 'Try again when both devices are connected.',
+      retryable: true,
+    ),
   );
 }
 
 rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
   required BigInt receivedBytes,
-  String errorMessage = 'Drift lost the connection while receiving files.',
 }) {
   return rust_receiver.ReceiverTransferEvent(
     phase: rust_receiver.ReceiverTransferPhase.failed,
@@ -341,7 +358,13 @@ rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
     bytesReceived: receivedBytes,
     totalSizeLabel: '18 KB',
     files: const [],
-    errorMessage: errorMessage,
+    error: const rust_error.UserFacingErrorData(
+      kind: rust_error.UserFacingErrorKindData.connectionLost,
+      title: 'Connection lost',
+      message: 'Drift lost the connection while receiving files.',
+      recovery: 'Try again when both devices are connected.',
+      retryable: true,
+    ),
   );
 }
 
@@ -813,6 +836,75 @@ void main() {
       await _flushAsyncWork(tester);
     },
   );
+
+  testWidgets('send selection failure stays visible on the idle screen', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final sendItemSource = FakeSendItemSource(
+      pickFilesError: Exception('permission denied'),
+    );
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      sendItemSource: sendItemSource,
+    );
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    final notifier = container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    notifier.pickSendItems();
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<IdleSession>());
+    expect(
+      state.sendSetupErrorMessage,
+      'Drift couldn\'t prepare the selected files.',
+    );
+  });
+
+  testWidgets('send cancel failure becomes a terminal send error', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final sendTransferSource = FakeSendTransferSource(
+      cancelError: Exception('cancel failed'),
+    );
+    final container = _buildContainer(
+      receiverServiceSource: receiverService,
+      sendTransferSource: sendTransferSource,
+    );
+    addTearDown(sendTransferSource.dispose);
+    addTearDown(receiverService.dispose);
+    addTearDown(container.dispose);
+
+    final notifier = container.read(driftAppNotifierProvider.notifier);
+    await _flushAsyncWork(tester);
+
+    notifier.pickSendItems();
+    await _flushAsyncWork(tester);
+    notifier.updateSendDestinationCode('ab2cd3');
+    await _flushAsyncWork(tester);
+    notifier.startSend();
+    await _flushAsyncWork(tester);
+    sendTransferSource.controller.add(
+      _sendUpdate(phase: SendTransferUpdatePhase.connecting),
+    );
+    await _flushAsyncWork(tester);
+
+    notifier.cancelSendInProgress();
+    await _flushAsyncWork(tester);
+
+    final state = container.read(driftAppNotifierProvider);
+    expect(state.session, isA<SendResultSession>());
+    expect(state.transferResult?.outcome, TransferResultOutcomeData.failed);
+    expect(
+      state.transferResult?.message,
+      'Drift couldn\'t cancel the transfer.',
+    );
+  });
 
   testWidgets(
     'incoming offers move to review and accept/decline use receiver service',

--- a/flutter/test/widget_test.dart
+++ b/flutter/test/widget_test.dart
@@ -12,6 +12,7 @@ import 'package:drift_app/state/drift_providers.dart';
 import 'package:drift_app/state/nearby_discovery_source.dart';
 import 'package:drift_app/state/receiver_service_source.dart';
 import 'package:drift_app/state/settings_store.dart';
+import 'package:drift_app/src/rust/api/error.dart' as rust_error;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -177,6 +178,7 @@ class FakeSendItemSource implements SendItemSource {
     required List<TransferItemViewData> pickedItems,
     List<List<String>>? pickResponses,
     Map<String, TransferItemViewData>? itemCatalog,
+    this.pickFilesError,
   }) : _pickResponses =
            pickResponses ??
            [pickedItems.map((item) => item.path).toList(growable: false)],
@@ -187,11 +189,13 @@ class FakeSendItemSource implements SendItemSource {
 
   final List<List<String>> _pickResponses;
   final Map<String, TransferItemViewData> _itemCatalog;
+  final Object? pickFilesError;
   int _pickIndex = 0;
 
   @override
-  Future<List<TransferItemViewData>> pickFiles() async =>
-      _mapPaths(_nextPickResponse());
+  Future<List<TransferItemViewData>> pickFiles() async => pickFilesError == null
+      ? _mapPaths(_nextPickResponse())
+      : Future<List<TransferItemViewData>>.error(pickFilesError!);
 
   @override
   Future<List<String>> pickAdditionalPaths() async => _nextPickResponse();
@@ -285,8 +289,11 @@ class FakeNearbyDiscoverySource implements NearbyDiscoverySource {
 }
 
 class FakeSendTransferSource implements SendTransferSource {
+  FakeSendTransferSource({this.cancelError});
+
   SendTransferRequestData? lastRequest;
   StreamController<SendTransferUpdate>? _controller;
+  final Object? cancelError;
 
   @override
   Stream<SendTransferUpdate> startTransfer(SendTransferRequestData request) {
@@ -298,6 +305,9 @@ class FakeSendTransferSource implements SendTransferSource {
 
   @override
   Future<void> cancelTransfer() async {
+    if (cancelError != null) {
+      throw cancelError!;
+    }
     _controller?.add(
       sendTransferUpdate(
         phase: SendTransferUpdatePhase.cancelled,
@@ -410,7 +420,6 @@ rust_receiver.ReceiverTransferEvent _incomingOfferEvent() {
 
 rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
   required BigInt receivedBytes,
-  String errorMessage = 'Drift lost the connection while receiving files.',
 }) {
   return rust_receiver.ReceiverTransferEvent(
     phase: rust_receiver.ReceiverTransferPhase.failed,
@@ -424,7 +433,13 @@ rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
     bytesReceived: receivedBytes,
     totalSizeLabel: '18 KB',
     files: const [],
-    errorMessage: errorMessage,
+    error: const rust_error.UserFacingErrorData(
+      kind: rust_error.UserFacingErrorKindData.connectionLost,
+      title: 'Connection lost',
+      message: 'Drift lost the connection while receiving files.',
+      recovery: 'Try again when both devices are connected.',
+      retryable: true,
+    ),
   );
 }
 
@@ -530,6 +545,30 @@ void main() {
     expect(find.text('Drop files to send'), findsOneWidget);
     expect(find.text('Send with code'), findsNothing);
     expect(shellBackButton(), findsNothing);
+    expectNoFlutterError(tester);
+  });
+
+  testWidgets('send selection failure is shown on the idle picker', (
+    tester,
+  ) async {
+    await pumpUtilityApp(
+      tester,
+      container: buildTestContainer(
+        sendItemSource: FakeSendItemSource(
+          pickedItems: const [],
+          pickFilesError: Exception('permission denied'),
+        ),
+      ),
+    );
+
+    await tester.tap(chooseFilesButton());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Drop files to send'), findsOneWidget);
+    expect(
+      find.text('Drift couldn\'t prepare the selected files.'),
+      findsOneWidget,
+    );
     expectNoFlutterError(tester);
   });
 
@@ -936,6 +975,47 @@ void main() {
     expectNoFlutterError(tester);
   });
 
+  testWidgets('cancel failure during send shows a terminal error', (
+    tester,
+  ) async {
+    final sendTransferSource = FakeSendTransferSource(
+      cancelError: Exception('cancel failed'),
+    );
+    final container = buildTestContainer(
+      sendTransferSource: sendTransferSource,
+    );
+    await pumpUtilityApp(tester, container: container);
+
+    await tester.tap(chooseFilesButton());
+    await tester.pumpAndSettle();
+    await tester.enterText(sendCodeField(), 'ab2cd3');
+    await tester.pump();
+
+    await tester.tap(find.text('Send'));
+    await tester.pump();
+
+    sendTransferSource.emit(
+      sendTransferUpdate(
+        phase: SendTransferUpdatePhase.connecting,
+        destinationLabel: 'Code AB2 CD3',
+        statusMessage: 'Request sent',
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Yes, cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Transfer failed'), findsOneWidget);
+    expect(find.text('Drift couldn\'t cancel the transfer.'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+    container.read(driftAppNotifierProvider.notifier).resetShell();
+    await tester.pumpAndSettle();
+    expectNoFlutterError(tester);
+  });
+
   testWidgets(
     'nearby device selection starts send with LAN ticket after Send',
     (tester) async {
@@ -1104,6 +1184,27 @@ void main() {
     expect(find.text('Nearby devices'), findsOneWidget);
     expect(find.text('No nearby devices found'), findsOneWidget);
     expect(sendCodeField(), findsOneWidget);
+    container.read(driftAppNotifierProvider.notifier).resetShell();
+    await tester.pumpAndSettle();
+    expectNoFlutterError(tester);
+  });
+
+  testWidgets('nearby scan failure is shown in the send draft', (tester) async {
+    Future<List<SendDestinationViewData>> failingScan() async {
+      throw Exception('mdns unavailable');
+    }
+
+    final container = buildTestContainer(nearbySendScan: failingScan);
+    await pumpUtilityApp(tester, container: container);
+
+    await tester.tap(chooseFilesButton());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Send with code'), findsOneWidget);
+    expect(
+      find.text('Drift couldn\'t scan for nearby devices right now.'),
+      findsOneWidget,
+    );
     container.read(driftAppNotifierProvider.notifier).resetShell();
     await tester.pumpAndSettle();
     expectNoFlutterError(tester);

--- a/flutter/test/widget_test.dart
+++ b/flutter/test/widget_test.dart
@@ -325,9 +325,13 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
       status: 'Ready',
       phase: ReceiverBadgePhase.ready,
     ),
+    this.respondError,
+    this.cancelError,
   });
 
   final ReceiverBadgeState initialBadge;
+  final Object? respondError;
+  final Object? cancelError;
   final StreamController<ReceiverBadgeState> _badgeController =
       StreamController<ReceiverBadgeState>.broadcast();
   final StreamController<rust_receiver.ReceiverTransferEvent>
@@ -337,7 +341,11 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
   final List<bool> respondToOfferCalls = <bool>[];
 
   @override
-  Future<void> cancelTransfer() async {}
+  Future<void> cancelTransfer() async {
+    if (cancelError != null) {
+      throw cancelError!;
+    }
+  }
 
   void emitBadge(ReceiverBadgeState badge) {
     _badgeController.add(badge);
@@ -354,6 +362,9 @@ class FakeReceiverServiceSource implements ReceiverServiceSource {
 
   @override
   Future<void> respondToOffer({required bool accept}) async {
+    if (respondError != null) {
+      throw respondError!;
+    }
     respondToOfferCalls.add(accept);
   }
 
@@ -394,6 +405,42 @@ rust_receiver.ReceiverTransferEvent _incomingOfferEvent() {
         size: BigInt.from(18 * 1024),
       ),
     ],
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingFailedEvent({
+  required BigInt receivedBytes,
+  String errorMessage = 'Drift lost the connection while receiving files.',
+}) {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.failed,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer failed.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: receivedBytes,
+    totalSizeLabel: '18 KB',
+    files: const [],
+    errorMessage: errorMessage,
+  );
+}
+
+rust_receiver.ReceiverTransferEvent _incomingDeclinedEvent() {
+  return rust_receiver.ReceiverTransferEvent(
+    phase: rust_receiver.ReceiverTransferPhase.declined,
+    senderName: 'Maya',
+    senderDeviceType: 'phone',
+    destinationLabel: 'Downloads',
+    saveRootLabel: 'Downloads',
+    statusMessage: 'Transfer declined.',
+    itemCount: BigInt.one,
+    totalSizeBytes: BigInt.from(18 * 1024),
+    bytesReceived: BigInt.zero,
+    totalSizeLabel: '18 KB',
+    files: const [],
   );
 }
 
@@ -569,7 +616,14 @@ void main() {
     await tester.tap(find.text('Decline'));
     await pumpUiSettled(tester);
 
-    expect(find.text('Tap to choose files to send.'), findsOneWidget);
+    receiverService.emitIncoming(_incomingDeclinedEvent());
+    await pumpUiSettled(tester);
+
+    expect(find.text('Transfer declined'), findsOneWidget);
+    expect(
+      find.text('The transfer was declined before any files were received.'),
+      findsOneWidget,
+    );
     expectNoFlutterError(tester);
   });
 
@@ -615,6 +669,63 @@ void main() {
 
     expect(find.text('Tap to choose files to send.'), findsOneWidget);
     expectNoFlutterError(tester);
+  });
+
+  testWidgets('mobile receive failure stays on a transfer error state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = buildTestContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    await pumpMobileShell(tester, container: container);
+
+    receiverService.emitIncoming(_incomingOfferEvent());
+    await pumpUiSettled(tester);
+    await tester.tap(saveToDownloadsButton());
+    await pumpUiSettled(tester);
+
+    receiverService.emitIncoming(
+      _incomingFailedEvent(receivedBytes: BigInt.from(9 * 1024)),
+    );
+    await pumpUiSettled(tester);
+
+    expect(find.text('Couldn\'t finish receiving files'), findsOneWidget);
+    expect(
+      find.text('Drift lost the connection while receiving files.'),
+      findsOneWidget,
+    );
+    expect(find.text('Done'), findsOneWidget);
+
+    await tester.tap(find.text('Done'));
+    await pumpUiSettled(tester);
+
+    expect(find.text('Tap to choose files to send.'), findsOneWidget);
+    expectNoFlutterError(tester);
+  });
+
+  testWidgets('mobile receive declined stays on a terminal declined state', (
+    tester,
+  ) async {
+    final receiverService = FakeReceiverServiceSource();
+    final container = buildTestContainer(
+      receiverServiceSource: receiverService,
+      enableIdleIncomingListener: true,
+    );
+    await pumpMobileShell(tester, container: container);
+
+    receiverService.emitIncoming(_incomingOfferEvent());
+    await pumpUiSettled(tester);
+    receiverService.emitIncoming(_incomingDeclinedEvent());
+    await pumpUiSettled(tester);
+
+    expect(find.text('Transfer declined'), findsOneWidget);
+    expect(
+      find.text('The transfer was declined before any files were received.'),
+      findsOneWidget,
+    );
+    expect(find.text('Done'), findsOneWidget);
   });
 
   testWidgets('after drop state routes straight to manual code entry', (
@@ -809,7 +920,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Transfer cancelled'), findsOneWidget);
-    expect(find.text('Transfer cancelled.'), findsOneWidget);
+    expect(
+      find.text('The transfer was stopped before all files were sent.'),
+      findsOneWidget,
+    );
+    expect(find.text('Send again'), findsOneWidget);
+
+    await tester.tap(find.text('Send again'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Send with code'), findsOneWidget);
+    expect(find.text('sample.txt'), findsWidgets);
     container.read(driftAppNotifierProvider.notifier).resetShell();
     await tester.pumpAndSettle();
     expectNoFlutterError(tester);
@@ -883,60 +1004,60 @@ void main() {
     expectNoFlutterError(tester);
   });
 
-  testWidgets(
-    'send failure shows the rust error and back returns to selection',
-    (tester) async {
-      final sendTransferSource = FakeSendTransferSource();
-      final container = buildTestContainer(
-        sendTransferSource: sendTransferSource,
-      );
-      await pumpUtilityApp(tester, container: container);
+  testWidgets('send failure shows retry action and preserves selection', (
+    tester,
+  ) async {
+    final sendTransferSource = FakeSendTransferSource();
+    final container = buildTestContainer(
+      sendTransferSource: sendTransferSource,
+    );
+    await pumpUtilityApp(tester, container: container);
 
-      await tester.tap(chooseFilesButton());
-      await tester.pumpAndSettle();
-      await tester.enterText(sendCodeField(), 'ab2cd3');
-      await tester.pump();
+    await tester.tap(chooseFilesButton());
+    await tester.pumpAndSettle();
+    await tester.enterText(sendCodeField(), 'ab2cd3');
+    await tester.pump();
 
-      await tester.tap(find.text('Send'));
-      await tester.pump();
+    await tester.tap(find.text('Send'));
+    await tester.pump();
 
-      sendTransferSource.emit(
-        sendTransferUpdate(
-          phase: SendTransferUpdatePhase.connecting,
-          destinationLabel: 'Code AB2 CD3',
-          statusMessage: 'Request sent',
-        ),
-      );
-      await tester.pumpAndSettle();
+    sendTransferSource.emit(
+      sendTransferUpdate(
+        phase: SendTransferUpdatePhase.connecting,
+        destinationLabel: 'Code AB2 CD3',
+        statusMessage: 'Request sent',
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      sendTransferSource.emit(
-        sendTransferUpdate(
-          phase: SendTransferUpdatePhase.failed,
-          destinationLabel: 'Code AB2 CD3',
-          statusMessage: 'Request sent',
-          errorMessage:
-              'receiver declined the offer: receiver declined the offer',
-        ),
-      );
-      await sendTransferSource.finish();
-      await tester.pumpAndSettle();
+    sendTransferSource.emit(
+      sendTransferUpdate(
+        phase: SendTransferUpdatePhase.failed,
+        destinationLabel: 'Code AB2 CD3',
+        statusMessage: 'Request sent',
+        errorMessage:
+            'receiver declined the offer: receiver declined the offer',
+      ),
+    );
+    await sendTransferSource.finish();
+    await tester.pumpAndSettle();
 
-      expect(find.text('Transfer failed'), findsOneWidget);
-      expect(
-        find.text('receiver declined the offer: receiver declined the offer'),
-        findsOneWidget,
-      );
+    expect(find.text('Transfer failed'), findsOneWidget);
+    expect(
+      find.text('receiver declined the offer: receiver declined the offer'),
+      findsOneWidget,
+    );
+    expect(find.text('Try again'), findsOneWidget);
 
-      await tester.tap(shellBackButton());
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
 
-      expect(find.text('Send with code'), findsOneWidget);
-      expect(find.text('sample.txt'), findsWidgets);
-      container.read(driftAppNotifierProvider.notifier).resetShell();
-      await tester.pumpAndSettle();
-      expectNoFlutterError(tester);
-    },
-  );
+    expect(find.text('Send with code'), findsOneWidget);
+    expect(find.text('sample.txt'), findsWidgets);
+    container.read(driftAppNotifierProvider.notifier).resetShell();
+    await tester.pumpAndSettle();
+    expectNoFlutterError(tester);
+  });
 
   testWidgets('recipient fallback avoids raw unknown device labels', (
     tester,


### PR DESCRIPTION
## Summary
- add differentiated terminal transfer result states across send and receive
- keep receiver failures and declines visible instead of resetting back to idle
- surface accept/decline/cancel receive-action failures as terminal error states

## Testing
- flutter test test/state/drift_app_notifier_test.dart
- flutter test test/widget_test.dart