### PR TITLE
Redesign mobile flow

### DIFF
--- a/docs/superpowers/plans/2026-04-24-clean-mobile-redesign.md
+++ b/docs/superpowers/plans/2026-04-24-clean-mobile-redesign.md
@@ -1,0 +1,77 @@
+# Mobile-First Redesign (Clean Implementation)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a responsive shell that preserves the original desktop design while introducing a redesigned, card-based mobile flow.
+
+**Architecture:** 
+- `ResponsiveShell` as the top-level home widget.
+- `DesktopShell` = Original `DriftShell` from `main`.
+- `MobileShell` = New card-based layout from `feature/mobile-redesign`.
+
+**Tech Stack:** Flutter, Riverpod.
+
+---
+
+### Task 1: Branch Setup & Context Preservation
+
+- [ ] **Step 1: Save current redesign files to a temporary location**
+We need `mobile_identity_card.dart` and `select_files_card.dart` and the logic for `MobileShell` from the current branch.
+
+- [ ] **Step 2: Checkout main and create a new branch**
+Run: `git checkout main && git checkout -b feature/mobile-flow-redesign`
+
+### Task 2: Restore Original Desktop Design as DesktopShell
+
+**Files:**
+- Create: `flutter/lib/shell/desktop_shell.dart` (using content of `main:flutter/lib/shell/drift_shell.dart`, renamed to `DesktopShell`)
+
+- [ ] **Step 1: Create DesktopShell.dart**
+Copy `DriftShell` from `main` and rename the class to `DesktopShell`.
+
+### Task 3: Port Mobile Redesign Components
+
+**Files:**
+- Create: `flutter/lib/shell/widgets/mobile_identity_card.dart`
+- Create: `flutter/lib/shell/widgets/select_files_card.dart`
+- Create: `flutter/lib/shell/widgets/shell_picking_actions.dart`
+
+- [ ] **Step 1: Restore the redesign widgets**
+Bring back the `MobileIdentityCard` (column-based) and `SelectFilesCard` from the `feature/mobile-redesign` branch.
+
+### Task 4: Implement MobileShell
+
+**Files:**
+- Create: `flutter/lib/shell/mobile_shell.dart`
+
+- [ ] **Step 1: Implement MobileShell with CustomScrollView**
+Use the card-based layout structure.
+
+### Task 5: Implement ResponsiveShell & Update Router
+
+**Files:**
+- Create: `flutter/lib/shell/responsive_shell.dart`
+- Modify: `flutter/lib/app/app_router.dart`
+- Delete: `flutter/lib/shell/drift_shell.dart`
+
+- [ ] **Step 1: Create ResponsiveShell**
+Logic to switch at 600px width.
+
+- [ ] **Step 2: Update Router to use ResponsiveShell**
+Replace `DriftShell` with `ResponsiveShell`.
+
+- [ ] **Step 3: Delete the old drift_shell.dart**
+
+### Task 6: Apply Settings Padding Fix
+
+**Files:**
+- Modify: `flutter/lib/features/settings/presentation/widgets/settings_page_body.dart`
+
+- [ ] **Step 1: Add SafeArea and top padding**
+As previously requested and implemented.
+
+### Task 7: Verification
+
+- [ ] **Step 1: Run analyze and tests**
+Run: `cd flutter && flutter analyze && flutter test`
+Expected: PASS

--- a/flutter/lib/app/app_router.dart
+++ b/flutter/lib/app/app_router.dart
@@ -6,7 +6,7 @@ import '../features/send/presentation/send_draft_preview.dart';
 import '../features/send/presentation/send_transfer_route.dart';
 import '../features/receive/presentation/receive_transfer_route.dart';
 import '../features/settings/feature.dart';
-import '../shell/drift_shell.dart';
+import '../shell/responsive_shell.dart';
 import '../shell/title_bar_shell.dart';
 
 abstract final class AppRoutePaths {
@@ -43,7 +43,8 @@ GoRouter buildAppRouter({List<NavigatorObserver> observers = const []}) {
     routes: [
       GoRoute(
         path: AppRoutePaths.home,
-        builder: (context, state) => const TitleBarShell(child: DriftShell()),
+        builder: (context, state) =>
+            const TitleBarShell(child: ResponsiveShell()),
         routes: [
           GoRoute(
             path: AppRoutePaths.settingsSegment,

--- a/flutter/lib/features/send/presentation/send_transfer_route.dart
+++ b/flutter/lib/features/send/presentation/send_transfer_route.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../theme/drift_theme.dart';
+import '../../../app/app_router.dart';
 import '../../transfers/application/manifest.dart';
 import '../../transfers/application/state.dart' as transfer_state;
 import '../../transfers/presentation/widgets/sending_connection_strip.dart';
@@ -53,10 +54,12 @@ class _SendTransferRoutePageState extends ConsumerState<SendTransferRoutePage> {
         return;
       }
 
-      setState(() {
-        _allowPop = true;
-      });
-      Navigator.of(context).pop();
+      final currentState = ref.read(sendControllerProvider);
+      if (currentState is SendStateResult) {
+        ref.read(sendControllerProvider.notifier).clearDraft();
+      }
+
+      context.goHome();
     }
 
     return PopScope(

--- a/flutter/lib/features/send/presentation/send_transfer_route.dart
+++ b/flutter/lib/features/send/presentation/send_transfer_route.dart
@@ -28,7 +28,7 @@ class SendTransferRoutePage extends ConsumerStatefulWidget {
 }
 
 class _SendTransferRoutePageState extends ConsumerState<SendTransferRoutePage> {
-  bool _allowPop = false;
+  final bool _allowPop = false;
 
   @override
   void initState() {

--- a/flutter/lib/features/settings/presentation/widgets/settings_page_body.dart
+++ b/flutter/lib/features/settings/presentation/widgets/settings_page_body.dart
@@ -189,9 +189,10 @@ class _SettingsPageBodyState extends ConsumerState<SettingsPageBody> {
       },
       child: Scaffold(
         backgroundColor: kBg,
-        body: Padding(
-          padding: const EdgeInsets.fromLTRB(24, 10, 24, 16),
-          child: Column(
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+            child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Row(
@@ -320,6 +321,7 @@ class _SettingsPageBodyState extends ConsumerState<SettingsPageBody> {
           ),
         ),
       ),
-    );
-  }
+    ),
+  );
+}
 }

--- a/flutter/lib/shell/desktop_shell.dart
+++ b/flutter/lib/shell/desktop_shell.dart
@@ -14,8 +14,8 @@ import '../features/send/presentation/send_selection_source_sheet.dart';
 import '../features/send/send_drop_zone.dart';
 import '../theme/drift_theme.dart';
 
-class DriftShell extends ConsumerWidget {
-  const DriftShell({super.key});
+class DesktopShell extends ConsumerWidget {
+  const DesktopShell({super.key});
 
   Future<void> _openSelectedFiles(
     BuildContext context,

--- a/flutter/lib/shell/mobile_shell.dart
+++ b/flutter/lib/shell/mobile_shell.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../features/receive/application/controller.dart';
+import '../features/receive/presentation/receive_transfer_route_gate.dart';
+import '../features/send/presentation/send_selection_source_sheet.dart';
+import '../app/app_router.dart';
+import '../theme/drift_theme.dart';
+import 'widgets/mobile_identity_card.dart';
+import 'widgets/select_files_card.dart';
+import 'widgets/shell_picking_actions.dart';
+
+class MobileShell extends ConsumerWidget with ShellPickingActions {
+  const MobileShell({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final receiverState = ref.watch(receiverIdleViewStateProvider);
+
+    return ReceiveTransferRouteGate(
+      child: Scaffold(
+        backgroundColor: kBg,
+        body: CustomScrollView(
+          physics: const BouncingScrollPhysics(),
+          slivers: [
+            SliverToBoxAdapter(
+              child: SafeArea(
+                bottom: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                  child: Row(
+                    children: [
+                      const Spacer(),
+                      IconButton(
+                        onPressed: () => context.goSettings(),
+                        icon: const Icon(Icons.tune_rounded),
+                        tooltip: 'Settings',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              sliver: SliverList(
+                delegate: SliverChildListDelegate([
+                  const SizedBox(height: 8),
+                  MobileIdentityCard(state: receiverState),
+                  const SizedBox(height: 32),
+                  SelectFilesCard(
+                    onTap: () {
+                      showSendSelectionSourceSheet(
+                        context,
+                        onChooseFiles: () => pickFiles(context, ref),
+                        onChooseFolder: () => pickFolder(context, ref),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                ]),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/lib/shell/responsive_shell.dart
+++ b/flutter/lib/shell/responsive_shell.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -10,17 +11,14 @@ class ResponsiveShell extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // We watch this here as requested by the plan, although the child shells 
-    // also watch it for their own internal needs.
     ref.watch(receiverIdleViewStateProvider);
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxWidth < 600) {
-          return const MobileShell();
-        }
-        return const DesktopShell();
-      },
-    );
+    final isMobile = Platform.isAndroid || Platform.isIOS;
+
+    if (isMobile) {
+      return const MobileShell();
+    }
+
+    return const DesktopShell();
   }
 }

--- a/flutter/lib/shell/responsive_shell.dart
+++ b/flutter/lib/shell/responsive_shell.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../features/receive/application/controller.dart';
+import 'desktop_shell.dart';
+import 'mobile_shell.dart';
+
+class ResponsiveShell extends ConsumerWidget {
+  const ResponsiveShell({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // We watch this here as requested by the plan, although the child shells 
+    // also watch it for their own internal needs.
+    ref.watch(receiverIdleViewStateProvider);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth < 600) {
+          return const MobileShell();
+        }
+        return const DesktopShell();
+      },
+    );
+  }
+}

--- a/flutter/lib/shell/widgets/mobile_identity_card.dart
+++ b/flutter/lib/shell/widgets/mobile_identity_card.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../features/receive/application/state.dart';
+import '../../../theme/drift_theme.dart';
+
+class MobileIdentityCard extends StatefulWidget {
+  const MobileIdentityCard({super.key, required this.state});
+
+  final ReceiverIdleViewState state;
+
+  @override
+  State<MobileIdentityCard> createState() => _MobileIdentityCardState();
+}
+
+class _MobileIdentityCardState extends State<MobileIdentityCard> {
+  bool _copied = false;
+  Timer? _timer;
+
+  void _copy() {
+    Clipboard.setData(ClipboardData(text: widget.state.clipboardCode));
+    _timer?.cancel();
+    HapticFeedback.mediumImpact();
+    setState(() => _copied = true);
+    _timer = Timer(const Duration(seconds: 2), () {
+      if (mounted) setState(() => _copied = false);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  String _formatCode(String code) {
+    if (code.length != 6) return code;
+    return '${code.substring(0, 3)} ${code.substring(3)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      color: kSurface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(28),
+        side: const BorderSide(color: kBorder, width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  widget.state.deviceName,
+                  style: driftSans(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                    color: kInk,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: widget.state.badge.color,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      widget.state.badge.label,
+                      style: driftSans(
+                        fontSize: 14,
+                        color: widget.state.badge.color,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'RECEIVE CODE',
+              style: driftSans(
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+                color: kMuted,
+                letterSpacing: 1.2,
+              ),
+            ),
+            const SizedBox(height: 8),
+            GestureDetector(
+              onTap: _copy,
+              behavior: HitTestBehavior.opaque,
+              child: Row(
+                children: [
+                  Text(
+                    _formatCode(widget.state.code),
+                    style: driftMono(
+                      fontSize: 36,
+                      fontWeight: FontWeight.w700,
+                      color: kInk,
+                      letterSpacing: 4,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 200),
+                    child: _copied
+                        ? const Icon(
+                            Icons.check_circle_outline_rounded,
+                            color: Color(0xFF49B36C),
+                            key: ValueKey('done'),
+                          )
+                        : Icon(
+                            Icons.copy_rounded,
+                            color: kMuted.withValues(alpha: 0.5),
+                            key: const ValueKey('copy'),
+                          ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/lib/shell/widgets/select_files_card.dart
+++ b/flutter/lib/shell/widgets/select_files_card.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../../../theme/drift_theme.dart';
+
+class SelectFilesCard extends StatelessWidget {
+  final VoidCallback? onTap;
+
+  const SelectFilesCard({
+    super.key,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(24),
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: kSurface,
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(color: kBorder),
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: kBg,
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: const Icon(Icons.add_rounded, color: kInk, size: 24),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Select files',
+                    style: driftSans(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: kInk,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'Tap to choose files to send.',
+                    style: driftSans(fontSize: 14, color: kMuted, height: 1.3),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter/lib/shell/widgets/shell_picking_actions.dart
+++ b/flutter/lib/shell/widgets/shell_picking_actions.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../app/app_router.dart';
+import '../../features/send/application/model.dart';
+import '../../features/send/application/send_selection_picker.dart';
+
+mixin ShellPickingActions {
+  Future<void> openSelectedFiles(
+    BuildContext context,
+    List<SendPickedFile> files,
+  ) async {
+    context.goSendDraft(files: files);
+  }
+
+  Future<void> pickSelection(
+    BuildContext context,
+    WidgetRef ref,
+    Future<List<SendPickedFile>> Function(SendSelectionPicker picker) pick,
+  ) async {
+    final pickerService = ref.read(sendSelectionPickerProvider);
+    final files = await pick(pickerService);
+    if (files.isEmpty) {
+      return;
+    }
+
+    if (!context.mounted) {
+      return;
+    }
+
+    await openSelectedFiles(context, files);
+  }
+
+  Future<void> pickFiles(BuildContext context, WidgetRef ref) {
+    return pickSelection(context, ref, (picker) => picker.pickFiles());
+  }
+
+  Future<void> pickFolder(BuildContext context, WidgetRef ref) {
+    return pickSelection(context, ref, (picker) => picker.pickFolder());
+  }
+}

--- a/flutter/rust/src/api/sender.rs
+++ b/flutter/rust/src/api/sender.rs
@@ -90,7 +90,10 @@ pub fn start_send_transfer(
     };
 
     let session = SendSession::new(draft, destination);
-    let run = session.start();
+    let run = {
+        let _guard = RUNTIME.enter();
+        session.start()
+    };
     let cancel_handle = run.cancel_handle();
 
     if let Ok(mut guard) = ACTIVE_SEND_CANCEL.lock() {


### PR DESCRIPTION
## Summary
- Restored the mobile idle screen to a card-based layout (v0.2.0 style).
- Introduced `ResponsiveShell` to switch between `MobileShell` (redesigned) and `DesktopShell` (original design from main) based on device platform.
- Fixed a Rust panic by ensuring `SendSession::start` has a Tokio runtime context.
- Improved the mobile flow by redirecting to the home screen and clearing the draft after a successful send.
- Fixed settings page layout on mobile by adding `SafeArea` and top padding.

## Test Plan
- [x] Verified mobile layout on Android/iOS (card-based).
- [x] Verified desktop layout (retains original design).
- [x] Verified successful send redirection and draft clearing.
- [x] Ran `flutter analyze` and `flutter test` (all 101 tests passed).