### PR TITLE
wire prepared sender manifest

### DIFF
--- a/crates/app/src/send/session.rs
+++ b/crates/app/src/send/session.rs
@@ -269,14 +269,14 @@ fn map_sender_event(
     event: CoreSenderEvent,
 ) -> SendEvent {
     match event {
-        CoreSenderEvent::Connecting { .. } => SendEvent {
+        CoreSenderEvent::Connecting { prepared_plan, .. } => SendEvent {
             phase: SendPhase::Connecting,
             destination_label: current_label.clone(),
             status_message: "Request sent".to_owned(),
             item_count: preview.file_count,
             total_size: preview.total_size,
             bytes_sent: 0,
-            plan: None,
+            plan: Some(prepared_plan),
             snapshot: None,
             remote_device_type: None,
             connection_path: None,
@@ -285,6 +285,7 @@ fn map_sender_event(
         CoreSenderEvent::WaitingForDecision {
             receiver_device_name,
             receiver_endpoint_id: _,
+            prepared_plan,
             ..
         } => {
             *current_label = display_destination_label(&receiver_device_name);
@@ -295,7 +296,7 @@ fn map_sender_event(
                 item_count: preview.file_count,
                 total_size: preview.total_size,
                 bytes_sent: 0,
-                plan: None,
+                plan: Some(prepared_plan),
                 snapshot: None,
                 remote_device_type: None,
                 connection_path: None,
@@ -305,6 +306,7 @@ fn map_sender_event(
         CoreSenderEvent::Accepted {
             receiver_device_name,
             receiver_endpoint_id: _,
+            prepared_plan,
             ..
         } => {
             *current_label = display_destination_label(&receiver_device_name);
@@ -315,21 +317,25 @@ fn map_sender_event(
                 item_count: preview.file_count,
                 total_size: preview.total_size,
                 bytes_sent: 0,
-                plan: None,
+                plan: Some(prepared_plan),
                 snapshot: None,
                 remote_device_type: None,
                 connection_path: None,
                 error: None,
             }
         }
-        CoreSenderEvent::Declined { reason, .. } => SendEvent {
+        CoreSenderEvent::Declined {
+            reason,
+            prepared_plan,
+            ..
+        } => SendEvent {
             phase: SendPhase::Declined,
             destination_label: current_label.clone(),
             status_message: "Transfer declined.".to_owned(),
             item_count: preview.file_count,
             total_size: preview.total_size,
             bytes_sent: 0,
-            plan: None,
+            plan: Some(prepared_plan),
             snapshot: None,
             remote_device_type: None,
             connection_path: None,
@@ -339,14 +345,18 @@ fn map_sender_event(
                 reason,
             )),
         },
-        CoreSenderEvent::Failed { error, .. } => SendEvent {
+        CoreSenderEvent::Failed {
+            error,
+            prepared_plan,
+            ..
+        } => SendEvent {
             phase: SendPhase::Failed,
             destination_label: current_label.clone(),
             status_message: format!("Starting transfer to {current_label}."),
             item_count: preview.file_count,
             total_size: preview.total_size,
             bytes_sent: 0,
-            plan: None,
+            plan: Some(prepared_plan),
             snapshot: None,
             remote_device_type: None,
             connection_path: None,

--- a/crates/core/src/transfer/sender.rs
+++ b/crates/core/src/transfer/sender.rs
@@ -33,24 +33,29 @@ pub enum SenderEvent {
     Connecting {
         session_id: String,
         peer_endpoint_id: EndpointId,
+        prepared_plan: TransferPlan,
     },
     WaitingForDecision {
         session_id: String,
         receiver_device_name: String,
         receiver_endpoint_id: EndpointId,
+        prepared_plan: TransferPlan,
     },
     Accepted {
         session_id: String,
         receiver_device_name: String,
         receiver_endpoint_id: EndpointId,
+        prepared_plan: TransferPlan,
     },
     Declined {
         session_id: String,
         reason: String,
+        prepared_plan: TransferPlan,
     },
     Failed {
         session_id: String,
         error: TransferError,
+        prepared_plan: TransferPlan,
     },
     TransferStarted {
         session_id: String,
@@ -106,6 +111,12 @@ impl SenderEventSink {
         self.emit(SenderEvent::Failed {
             session_id: self.session_id.clone(),
             error,
+            prepared_plan: TransferPlan {
+                session_id: self.session_id.clone(),
+                total_files: 0,
+                total_bytes: 0,
+                files: Vec::new(),
+            },
         });
     }
 }
@@ -180,6 +191,7 @@ impl SenderSession {
     async fn run(self, mut cancel_rx: watch::Receiver<bool>) -> Result<TransferOutcome> {
         let scratch = ScratchDir::new("drift-send", &self.session_id).await?;
         let prepared = PreparedStore::prepare(&scratch.path, self.request.files.clone()).await?;
+        let prepared_plan = build_prepared_plan(&self.session_id, &prepared)?;
 
         info!(
             session_id = %self.session_id,
@@ -192,6 +204,7 @@ impl SenderSession {
         self.events.emit(SenderEvent::Connecting {
             session_id: self.session_id.clone(),
             peer_endpoint_id: self.request.peer_endpoint_id,
+            prepared_plan: prepared_plan.clone(),
         });
         let connection = self
             .endpoint
@@ -220,12 +233,14 @@ impl SenderSession {
                     session_id: self.session_id.clone(),
                     receiver_device_name: peer.identity.device_name.clone(),
                     receiver_endpoint_id: peer.identity.endpoint_id,
+                    prepared_plan: prepared_plan.clone(),
                 });
             }
             protocol_sender::SenderControlOutcome::Declined(declined) => {
                 self.events.emit(SenderEvent::Declined {
                     session_id: self.session_id.clone(),
                     reason: declined.reason,
+                    prepared_plan: prepared_plan.clone(),
                 });
                 return Ok(TransferOutcome::Declined {
                     reason: "receiver declined".to_owned(),
@@ -389,6 +404,16 @@ async fn do_transfer(
             }
         }
     }
+}
+
+fn build_prepared_plan(
+    session_id: &str,
+    prepared: &crate::blobs::send::PreparedStore,
+) -> Result<TransferPlan> {
+    Ok(TransferPlan::from_manifest(
+        session_id.to_owned(),
+        &prepared.manifest(),
+    )?)
 }
 
 fn from_wire_snapshot(

--- a/flutter/lib/features/send/application/controller.dart
+++ b/flutter/lib/features/send/application/controller.dart
@@ -5,6 +5,7 @@ import 'package:app/features/receive/application/state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'model.dart';
+import 'item_size.dart';
 import 'directory_size.dart';
 import '../../../platform/send_transfer_source.dart';
 import '../../transfers/application/format_utils.dart';
@@ -188,6 +189,7 @@ class SendController extends _$SendController {
       transfer: _buildInitialTransferState(
         validatedRequest,
         currentState.items,
+        currentState.resolvedDirectorySizes,
       ),
       resolvedDirectorySizes: currentState.resolvedDirectorySizes,
     );
@@ -291,13 +293,20 @@ class SendController extends _$SendController {
 
       final nextSizes = Map<String, BigInt>.from(resolvedSizes);
       nextSizes[path] = sizeBytes;
+      final totalSize = totalDraftItemSize(items, nextSizes);
 
       if (currentState is SendStateDrafting) {
         state = currentState.copyWith(resolvedDirectorySizes: nextSizes);
       } else if (currentState is SendStateTransferring) {
-        state = currentState.copyWith(resolvedDirectorySizes: nextSizes);
+        state = currentState.copyWith(
+          resolvedDirectorySizes: nextSizes,
+          transfer: currentState.transfer.copyWith(totalSize: totalSize),
+        );
       } else if (currentState is SendStateResult) {
-        state = currentState.copyWith(resolvedDirectorySizes: nextSizes);
+        state = currentState.copyWith(
+          resolvedDirectorySizes: nextSizes,
+          transfer: currentState.transfer.copyWith(totalSize: totalSize),
+        );
       }
     } finally {
       _pendingDirectorySizes.remove(path);
@@ -517,11 +526,9 @@ class SendController extends _$SendController {
   SendTransferState _buildInitialTransferState(
     SendRequestData request,
     List<SendDraftItem> items,
+    Map<String, BigInt> resolvedDirectorySizes,
   ) {
-    final totalSize = items.fold<BigInt>(
-      BigInt.zero,
-      (sum, item) => sum + item.sizeBytes,
-    );
+    final totalSize = totalDraftItemSize(items, resolvedDirectorySizes);
     return SendTransferState.connecting(
       destinationLabel:
           request.lanDestinationLabel ?? request.code ?? 'Recipient device',

--- a/flutter/lib/features/send/application/item_size.dart
+++ b/flutter/lib/features/send/application/item_size.dart
@@ -1,0 +1,22 @@
+import 'model.dart';
+
+BigInt effectiveDraftItemSize(
+  SendDraftItem item,
+  Map<String, BigInt> resolvedDirectorySizes,
+) {
+  if (item.kind == SendPickedFileKind.directory) {
+    return resolvedDirectorySizes[item.path] ?? item.sizeBytes;
+  }
+
+  return item.sizeBytes;
+}
+
+BigInt totalDraftItemSize(
+  Iterable<SendDraftItem> items,
+  Map<String, BigInt> resolvedDirectorySizes,
+) {
+  return items.fold<BigInt>(
+    BigInt.zero,
+    (sum, item) => sum + effectiveDraftItemSize(item, resolvedDirectorySizes),
+  );
+}

--- a/flutter/lib/features/send/presentation/send_draft_preview.dart
+++ b/flutter/lib/features/send/presentation/send_draft_preview.dart
@@ -9,6 +9,7 @@ import '../../../app/app_router.dart';
 import '../application/controller.dart';
 import '../../transfers/presentation/widgets/transfer_presentation_helpers.dart';
 import '../application/model.dart';
+import '../application/item_size.dart';
 import '../application/send_selection_picker.dart';
 import '../application/state.dart';
 import 'widgets/send_destination_selector.dart';
@@ -90,9 +91,7 @@ class SendDraftPreview extends ConsumerWidget {
 
     return items
         .map((item) {
-          final sizeBytes = item.kind == SendPickedFileKind.directory
-              ? (resolvedSizes[item.path] ?? item.sizeBytes)
-              : item.sizeBytes;
+          final sizeBytes = effectiveDraftItemSize(item, resolvedSizes);
           return SendPickedFile(
             path: item.path,
             name: item.name,

--- a/flutter/lib/features/send/presentation/send_transfer_route.dart
+++ b/flutter/lib/features/send/presentation/send_transfer_route.dart
@@ -8,13 +8,12 @@ import '../../transfers/application/state.dart' as transfer_state;
 import '../../transfers/presentation/widgets/sending_connection_strip.dart';
 import '../../transfers/presentation/widgets/transfer_flow_layout.dart';
 import '../../transfers/presentation/widgets/transfer_presentation_helpers.dart';
+import '../../transfers/presentation/widgets/transfer_manifest_panel.dart';
 import '../application/controller.dart';
 import '../application/model.dart';
 import '../application/state.dart';
 import '../application/transfer_state.dart';
 import 'send_transfer_view_data.dart';
-import 'package:app/features/transfers/presentation/widgets/manifest_tree_card.dart';
-import 'package:app/features/transfers/presentation/widgets/active_transfer_file_list.dart';
 import 'package:app/features/send/presentation/widgets/recipient_avatar.dart';
 
 class SendTransferRoutePage extends ConsumerStatefulWidget {
@@ -141,6 +140,14 @@ class _TransferStateCard extends StatelessWidget {
               TransferManifestItem(path: file.path, sizeBytes: file.sizeBytes),
         )
         .toList(growable: false);
+    final manifestMode = switch (state) {
+      SendStateTransferring(:final transfer)
+          when transfer.phase == SendTransferPhase.sending =>
+        TransferManifestPanelMode.liveList,
+      SendStateResult() => TransferManifestPanelMode.liveList,
+      SendStateTransferring() => TransferManifestPanelMode.previewTree,
+      _ => TransferManifestPanelMode.previewTree,
+    };
     final stripMode =
         viewData.stripMode ??
         (isSuccessResult
@@ -173,15 +180,12 @@ class _TransferStateCard extends StatelessWidget {
       ),
       manifest: manifestItems.isEmpty
           ? null
-          : (state is SendStateTransferring
-                ? ActiveTransferFileList(
-                    items: manifestItems,
-                    progress: progress,
-                  )
-                : ManifestTreeCard(
-                    items: manifestItems,
-                    initiallyExpanded: state is SendStateResult,
-                  )),
+          : TransferManifestPanel(
+              mode: manifestMode,
+              items: manifestItems,
+              progress: progress,
+              initiallyExpanded: state is SendStateResult,
+            ),
       footer: Row(
         children: [
           Expanded(

--- a/flutter/lib/features/send/presentation/send_transfer_view_data.dart
+++ b/flutter/lib/features/send/presentation/send_transfer_view_data.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../theme/drift_theme.dart';
 import '../../transfers/presentation/widgets/sending_connection_strip.dart';
 import '../../transfers/presentation/widgets/transfer_presentation_helpers.dart';
-import '../application/item_size.dart';
 import '../application/model.dart';
 import '../application/state.dart';
 import '../application/transfer_state.dart';

--- a/flutter/lib/features/send/presentation/send_transfer_view_data.dart
+++ b/flutter/lib/features/send/presentation/send_transfer_view_data.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../theme/drift_theme.dart';
 import '../../transfers/presentation/widgets/sending_connection_strip.dart';
 import '../../transfers/presentation/widgets/transfer_presentation_helpers.dart';
+import '../application/item_size.dart';
 import '../application/model.dart';
 import '../application/state.dart';
 import '../application/transfer_state.dart';
@@ -321,17 +322,21 @@ List<SendTransferMetricData> _metricsForState(SendState state) {
 }
 
 List<SendTransferFileViewData> _filesForState(SendState state) {
-  final (transfer, items, request) = switch (state) {
-    SendStateTransferring(:final transfer, :final items, :final request) => (
-      transfer,
-      items,
-      request,
-    ),
-    SendStateResult(:final transfer, :final items, :final request) => (
-      transfer,
-      items,
-      request,
-    ),
+  final (transfer, items, request, resolvedDirectorySizes) = switch (state) {
+    SendStateTransferring(
+      :final transfer,
+      :final items,
+      :final request,
+      :final resolvedDirectorySizes,
+    ) =>
+      (transfer, items, request, resolvedDirectorySizes),
+    SendStateResult(
+      :final transfer,
+      :final items,
+      :final request,
+      :final resolvedDirectorySizes,
+    ) =>
+      (transfer, items, request, resolvedDirectorySizes),
     _ => throw StateError('Files requires an active or completed transfer'),
   };
 
@@ -343,17 +348,7 @@ List<SendTransferFileViewData> _filesForState(SendState state) {
   );
 
   if (plan == null) {
-    return items
-        .map(
-          (item) => SendTransferFileViewData(
-            name: item.name,
-            path: _relativeDisplayPath(item.path, roots),
-            sizeBytes: item.sizeBytes,
-            sizeLabel: formatBytes(item.sizeBytes),
-            state: SendTransferFileState.pending,
-          ),
-        )
-        .toList(growable: false);
+    return const <SendTransferFileViewData>[];
   }
 
   return plan.files

--- a/flutter/lib/features/transfers/feature.dart
+++ b/flutter/lib/features/transfers/feature.dart
@@ -5,3 +5,4 @@ export 'application/service.dart';
 export 'application/state.dart';
 export 'presentation/view.dart';
 export 'presentation/widgets/manifest_tree.dart';
+export 'presentation/widgets/transfer_manifest_panel.dart';

--- a/flutter/lib/features/transfers/presentation/widgets/offer_card.dart
+++ b/flutter/lib/features/transfers/presentation/widgets/offer_card.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import '../../application/state.dart';
 import '../../../../theme/drift_theme.dart';
 import 'package:app/features/send/presentation/widgets/recipient_avatar.dart';
-import 'manifest_tree_card.dart';
 import 'sending_connection_strip.dart';
 import 'transfer_flow_layout.dart';
+import 'transfer_manifest_panel.dart';
 import 'transfer_presentation_helpers.dart';
 
 class OfferCard extends StatelessWidget {
@@ -53,7 +53,10 @@ class OfferCard extends StatelessWidget {
           animate: animate,
           mode: SendingStripMode.waitingOnRecipient,
         ),
-        manifest: ManifestTreeCard(items: offer.manifest.items),
+        manifest: TransferManifestPanel(
+          mode: TransferManifestPanelMode.previewTree,
+          items: offer.manifest.items,
+        ),
         footer: Row(
           children: [
             Expanded(

--- a/flutter/lib/features/transfers/presentation/widgets/receiving_card.dart
+++ b/flutter/lib/features/transfers/presentation/widgets/receiving_card.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../application/state.dart';
 import 'package:app/features/send/presentation/widgets/recipient_avatar.dart';
-import 'active_transfer_file_list.dart';
 import 'sending_connection_strip.dart';
 import 'transfer_flow_layout.dart';
+import 'transfer_manifest_panel.dart';
 import 'transfer_presentation_helpers.dart';
 
 class ReceivingCard extends ConsumerWidget {
@@ -54,7 +54,8 @@ class ReceivingCard extends ConsumerWidget {
           mode: SendingStripMode.transferring,
           progress: progress.progressFraction,
         ),
-        manifest: ActiveTransferFileList(
+        manifest: TransferManifestPanel(
+          mode: TransferManifestPanelMode.liveList,
           items: offer.manifest.items,
           progress: progress,
         ),

--- a/flutter/lib/features/transfers/presentation/widgets/transfer_manifest_panel.dart
+++ b/flutter/lib/features/transfers/presentation/widgets/transfer_manifest_panel.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../application/manifest.dart';
+import '../../application/state.dart';
+import 'active_transfer_file_list.dart';
+import 'manifest_tree_card.dart';
+
+enum TransferManifestPanelMode { previewTree, liveList }
+
+class TransferManifestPanel extends StatelessWidget {
+  const TransferManifestPanel({
+    super.key,
+    required this.mode,
+    required this.items,
+    this.progress,
+    this.initiallyExpanded = false,
+  });
+
+  final TransferManifestPanelMode mode;
+  final List<TransferManifestItem> items;
+  final TransferTransferProgress? progress;
+  final bool initiallyExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (mode) {
+      TransferManifestPanelMode.previewTree => ManifestTreeCard(
+        items: items,
+        initiallyExpanded: initiallyExpanded,
+      ),
+      TransferManifestPanelMode.liveList => ActiveTransferFileList(
+        items: items,
+        progress: progress,
+        initiallyExpanded: initiallyExpanded,
+      ),
+    };
+  }
+}

--- a/flutter/lib/features/transfers/presentation/widgets/transfer_result_card.dart
+++ b/flutter/lib/features/transfers/presentation/widgets/transfer_result_card.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:app/theme/drift_theme.dart';
 import 'package:app/features/send/presentation/widgets/recipient_avatar.dart';
 import 'package:app/features/transfers/application/result_view_data.dart';
-import 'package:app/features/transfers/presentation/widgets/active_transfer_file_list.dart';
+import 'package:app/features/transfers/presentation/widgets/transfer_manifest_panel.dart';
 import 'sending_connection_strip.dart';
 import 'transfer_flow_layout.dart';
 import 'transfer_presentation_helpers.dart';
@@ -46,7 +46,8 @@ class TransferResultCard extends StatelessWidget {
         manifest:
             viewData.manifestItems == null || viewData.manifestItems!.isEmpty
             ? null
-            : ActiveTransferFileList(
+            : TransferManifestPanel(
+                mode: TransferManifestPanelMode.liveList,
                 items: viewData.manifestItems!,
                 initiallyExpanded: true,
               ),

--- a/flutter/test/features/send/application/controller_test.dart
+++ b/flutter/test/features/send/application/controller_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:app/features/receive/application/state.dart';
 import 'package:app/features/send/application/controller.dart';
+import 'package:app/features/send/application/directory_size.dart';
 import 'package:app/features/send/application/model.dart';
 import 'package:app/features/send/application/state.dart';
 import 'package:app/features/send/application/transfer_state.dart';
@@ -66,6 +67,17 @@ class SequencedSendTransferSource implements SendTransferSource {
     for (final stream in _streams) {
       await stream.close();
     }
+  }
+}
+
+class FakeDirectorySizeCalculator implements DirectorySizeCalculator {
+  FakeDirectorySizeCalculator(this.sizes);
+
+  final Map<String, BigInt> sizes;
+
+  @override
+  Future<BigInt> sizeOfDirectory(String path) async {
+    return sizes[path] ?? BigInt.zero;
   }
 }
 
@@ -301,6 +313,37 @@ void main() {
             .phase,
         SendTransferPhase.completed,
       );
+    },
+  );
+
+  test(
+    'send controller uses resolved directory sizes when starting transfer',
+    () async {
+      final fakeSource = FakeSendTransferSource();
+      final container = ProviderContainer(
+        overrides: [
+          initialAppSettingsProvider.overrideWithValue(testAppSettings),
+          directorySizeCalculatorProvider.overrideWithValue(
+            FakeDirectorySizeCalculator({'/tmp/photos': BigInt.from(2048)}),
+          ),
+          sendTransferSourceProvider.overrideWithValue(fakeSource),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(fakeSource.close);
+
+      final controller = container.read(sendControllerProvider.notifier);
+      controller.beginDraft([SendPickedFile.directory('/tmp/photos')]);
+      controller.updateDestinationCode('ABC123');
+
+      await Future<void>.delayed(Duration.zero);
+
+      controller.startTransfer(controller.buildSendRequest()!);
+
+      final state =
+          container.read(sendControllerProvider) as SendStateTransferring;
+      expect(state.transfer.totalSize, BigInt.from(2048));
+      expect(state.resolvedDirectorySizes['/tmp/photos'], BigInt.from(2048));
     },
   );
 

--- a/flutter/test/features/send/presentation/send_transfer_route_test.dart
+++ b/flutter/test/features/send/presentation/send_transfer_route_test.dart
@@ -6,9 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:app/features/send/application/controller.dart';
+import 'package:app/features/send/application/directory_size.dart';
 import 'package:app/features/send/application/model.dart';
 import 'package:app/features/send/application/state.dart';
+import 'package:app/features/send/presentation/send_transfer_view_data.dart';
 import 'package:app/features/send/presentation/send_transfer_route.dart';
+import 'package:app/features/transfers/presentation/widgets/active_transfer_file_list.dart';
+import 'package:app/features/transfers/presentation/widgets/manifest_tree_card.dart';
 import 'package:app/features/send/presentation/widgets/recipient_avatar.dart';
 import 'package:app/features/settings/settings_providers.dart';
 import 'package:app/platform/send_transfer_source.dart';
@@ -42,6 +46,17 @@ class FakeSendTransferSource implements SendTransferSource {
   }
 }
 
+class FakeDirectorySizeCalculator implements DirectorySizeCalculator {
+  FakeDirectorySizeCalculator(this.sizes);
+
+  final Map<String, BigInt> sizes;
+
+  @override
+  Future<BigInt> sizeOfDirectory(String path) async {
+    return sizes[path] ?? BigInt.zero;
+  }
+}
+
 Future<void> _pumpRoute(WidgetTester tester) async {
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 200));
@@ -67,16 +82,33 @@ GoRouter _buildRouter(SendRequestData request) {
   );
 }
 
+ProviderContainer _buildContainer(FakeSendTransferSource fakeSource) {
+  return ProviderContainer(
+    overrides: [
+      initialAppSettingsProvider.overrideWithValue(testAppSettings),
+      directorySizeCalculatorProvider.overrideWithValue(
+        FakeDirectorySizeCalculator({'/tmp/photos': BigInt.from(2048)}),
+      ),
+      sendTransferSourceProvider.overrideWithValue(fakeSource),
+    ],
+  );
+}
+
 rust_transfer.TransferPlanData _buildPlan() {
   return rust_transfer.TransferPlanData(
     sessionId: 'session-1',
-    totalFiles: 1,
-    totalBytes: BigInt.from(1024),
+    totalFiles: 2,
+    totalBytes: BigInt.from(3072),
     files: [
       rust_transfer.TransferPlanFileData(
         id: 0,
-        path: '/tmp/report.pdf',
+        path: '/tmp/photos/a/report.pdf',
         size: BigInt.from(1024),
+      ),
+      rust_transfer.TransferPlanFileData(
+        id: 1,
+        path: '/tmp/photos/b/notes.txt',
+        size: BigInt.from(2048),
       ),
     ],
   );
@@ -104,15 +136,107 @@ rust_transfer.TransferSnapshotData _buildSnapshot({
 
 void main() {
   testWidgets(
+    'send transfer route shows a tree preview before sending and a live list after',
+    (WidgetTester tester) async {
+      final fakeSource = FakeSendTransferSource();
+      final container = _buildContainer(fakeSource);
+      addTearDown(container.dispose);
+      addTearDown(fakeSource.close);
+
+      final controller = container.read(sendControllerProvider.notifier);
+      controller.beginDraft([SendPickedFile.directory('/tmp/photos')]);
+      controller.updateDestinationCode('ABC123');
+      await tester.pump(const Duration(seconds: 1));
+      await tester.pump();
+
+      expect(
+        (container.read(sendControllerProvider) as SendStateDrafting)
+            .resolvedDirectorySizes['/tmp/photos'],
+        BigInt.from(2048),
+      );
+
+      final request = controller.buildSendRequest()!;
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(routerConfig: _buildRouter(request)),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump();
+      expect(find.byType(ManifestTreeCard), findsNothing);
+      expect(find.byType(ActiveTransferFileList), findsNothing);
+
+      fakeSource.emit(
+        SendTransferUpdate(
+          phase: SendTransferUpdatePhase.connecting,
+          destinationLabel: 'Laptop',
+          statusMessage: 'Preparing offer.',
+          itemCount: BigInt.two,
+          totalSize: BigInt.from(3072),
+          bytesSent: BigInt.zero,
+          totalBytes: BigInt.from(3072),
+          plan: _buildPlan(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump();
+
+      expect(find.byType(ManifestTreeCard), findsOneWidget);
+      expect(find.byType(ActiveTransferFileList), findsNothing);
+
+      fakeSource.emit(
+        SendTransferUpdate(
+          phase: SendTransferUpdatePhase.waitingForDecision,
+          destinationLabel: 'Laptop',
+          statusMessage: 'Waiting for confirmation.',
+          itemCount: BigInt.two,
+          totalSize: BigInt.from(3072),
+          bytesSent: BigInt.zero,
+          totalBytes: BigInt.from(3072),
+          plan: _buildPlan(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump();
+
+      expect(find.byType(ManifestTreeCard), findsOneWidget);
+      expect(find.byType(ActiveTransferFileList), findsNothing);
+      final waitingState =
+          container.read(sendControllerProvider) as SendStateTransferring;
+      final pageData = buildSendTransferPageData(
+        state: waitingState,
+        request: request,
+      );
+      expect(pageData.files, hasLength(2));
+      expect(pageData.files.first.sizeBytes, BigInt.from(1024));
+      expect(pageData.files.last.sizeBytes, BigInt.from(2048));
+
+      fakeSource.emit(
+        SendTransferUpdate(
+          phase: SendTransferUpdatePhase.sending,
+          destinationLabel: 'Laptop',
+          statusMessage: 'Sending files.',
+          itemCount: BigInt.two,
+          totalSize: BigInt.from(3072),
+          bytesSent: BigInt.from(256),
+          totalBytes: BigInt.from(3072),
+          plan: _buildPlan(),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump();
+
+      expect(find.byType(ManifestTreeCard), findsNothing);
+      expect(find.byType(ActiveTransferFileList), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'send transfer route shows connecting waiting accepted sending and completed states',
     (WidgetTester tester) async {
       final fakeSource = FakeSendTransferSource();
-      final container = ProviderContainer(
-        overrides: [
-          initialAppSettingsProvider.overrideWithValue(testAppSettings),
-          sendTransferSourceProvider.overrideWithValue(fakeSource),
-        ],
-      );
+      final container = _buildContainer(fakeSource);
       addTearDown(container.dispose);
       addTearDown(fakeSource.close);
 
@@ -287,12 +411,7 @@ void main() {
 
       for (final fixture in fixtures) {
         final fakeSource = FakeSendTransferSource();
-        final container = ProviderContainer(
-          overrides: [
-            initialAppSettingsProvider.overrideWithValue(testAppSettings),
-            sendTransferSourceProvider.overrideWithValue(fakeSource),
-          ],
-        );
+        final container = _buildContainer(fakeSource);
         addTearDown(container.dispose);
         addTearDown(fakeSource.close);
 


### PR DESCRIPTION
Thread the sender's prepared manifest through the early send events so the offer tree is visible once Send is clicked, then switch to the live list once transfer starts. Keep directory totals accurate and preserve the shared manifest panel across sender and receiver.

Closes #24.