### PR TITLE
fix: carry nearby device type into LAN discovery

### DIFF
--- a/crates/app/src/nearby.rs
+++ b/crates/app/src/nearby.rs
@@ -20,6 +20,10 @@ pub async fn scan_nearby_receivers(timeout_secs: u64) -> AppResult<Vec<NearbyRec
             NearbyReceiver {
                 fullname: receiver.fullname,
                 label: receiver.label,
+                device_type: match receiver.device_type {
+                    drift_core::protocol::DeviceType::Phone => "phone".to_owned(),
+                    drift_core::protocol::DeviceType::Laptop => "laptop".to_owned(),
+                },
                 code: receiver.code,
                 ticket: receiver.ticket,
             },

--- a/crates/app/src/receiver/actor.rs
+++ b/crates/app/src/receiver/actor.rs
@@ -180,6 +180,14 @@ pub(super) async fn run_receiver_actor(
                                 .map(|receiver| NearbyReceiver {
                                     fullname: receiver.fullname,
                                     label: receiver.label,
+                                    device_type: match receiver.device_type {
+                                        drift_core::protocol::DeviceType::Phone => {
+                                            "phone".to_owned()
+                                        }
+                                        drift_core::protocol::DeviceType::Laptop => {
+                                            "laptop".to_owned()
+                                        }
+                                    },
                                     code: receiver.code,
                                     ticket: receiver.ticket,
                                 })

--- a/crates/app/src/receiver/runtime.rs
+++ b/crates/app/src/receiver/runtime.rs
@@ -12,7 +12,7 @@ use crate::error::{AppError, AppResult};
 use crate::types::{PairingCodeState, ReceiverConfig, ReceiverRegistration};
 
 use super::session::ReceiverRun;
-use super::{OfferDecision, ReceiverEvent};
+use super::{OfferDecision, ReceiverEvent, parse_device_type};
 
 pub(super) struct ReceiverRuntime {
     config: ReceiverConfig,
@@ -354,7 +354,19 @@ impl ReceiverRuntime {
             }
         };
 
-        match LanReceiveAdvertisement::start(&ticket, &self.config.device_name) {
+        let device_type = match parse_device_type(&self.config.device_type) {
+            Ok(device_type) => device_type,
+            Err(error) => {
+                warn!(
+                    device = %self.config.device_name,
+                    error = %error,
+                    "receiver.lan_advertising_invalid_device_type"
+                );
+                return;
+            }
+        };
+
+        match LanReceiveAdvertisement::start(&ticket, &self.config.device_name, device_type) {
             Ok(Some(advertising)) => {
                 self.advertising = Some(advertising);
             }

--- a/crates/app/src/types.rs
+++ b/crates/app/src/types.rs
@@ -43,6 +43,7 @@ pub struct SendEvent {
 pub struct NearbyReceiver {
     pub fullname: String,
     pub label: String,
+    pub device_type: String,
     pub code: String,
     pub ticket: String,
 }

--- a/crates/core/src/discovery.rs
+++ b/crates/core/src/discovery.rs
@@ -167,6 +167,7 @@ mod tests {
         let receiver = lan::NearbyReceiver {
             fullname: "recv-1".to_owned(),
             label: "Receiver".to_owned(),
+            device_type: crate::protocol::DeviceType::Laptop,
             code: String::new(),
             ticket: "bad-ticket".to_owned(),
         };

--- a/crates/core/src/lan.rs
+++ b/crates/core/src/lan.rs
@@ -13,6 +13,8 @@ use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo, TxtProperties};
 use rand::seq::SliceRandom;
 use thiserror::Error;
 use tracing::info;
+
+use crate::protocol::DeviceType;
 /// DNS-SD type for drift receivers on the LAN (`drift` ≤ 15 bytes per RFC 6763).
 pub const DRIFT_MDNS_SERVICE_TYPE: &str = "_drift._udp.local.";
 
@@ -111,6 +113,20 @@ fn ticket_from_txt(txt: &TxtProperties) -> Option<String> {
         out.push_str(piece);
     }
     Some(out)
+}
+
+fn device_type_from_txt(txt: &TxtProperties) -> DeviceType {
+    match txt.get_property_val_str("dt") {
+        Some("phone") => DeviceType::Phone,
+        Some("laptop") | None | Some(_) => DeviceType::Laptop,
+    }
+}
+
+fn device_type_to_txt(device_type: DeviceType) -> &'static str {
+    match device_type {
+        DeviceType::Phone => "phone",
+        DeviceType::Laptop => "laptop",
+    }
 }
 
 fn build_presence_packet(op: u8, nonce: u64) -> [u8; PRESENCE_PKT_LEN] {
@@ -279,7 +295,11 @@ impl LanReceiveAdvertisement {
     /// Publishes the given iroh `ticket` (same string as rendezvous) on the LAN.
     ///
     /// Returns `Ok(None)` when there is no usable IPv4 default route (LAN advertising skipped).
-    pub fn start(ticket: &str, device_label: &str) -> std::result::Result<Option<Self>, LanError> {
+    pub fn start(
+        ticket: &str,
+        device_label: &str,
+        device_type: DeviceType,
+    ) -> std::result::Result<Option<Self>, LanError> {
         let ip = match default_route_ipv4() {
             Ok(ip) => ip,
             Err(_) => return Ok(None),
@@ -296,6 +316,7 @@ impl LanReceiveAdvertisement {
         let mut properties: Vec<(String, String)> = vec![
             ("ver".into(), DRIFT_MDNS_TXT_VER.into()),
             ("label".into(), device_label.to_owned()),
+            ("dt".into(), device_type_to_txt(device_type).into()),
             ("tc".into(), chunks.len().to_string()),
         ];
         for (i, c) in chunks.iter().enumerate() {
@@ -356,6 +377,7 @@ impl Drop for LanReceiveAdvertisement {
 pub struct NearbyReceiver {
     pub fullname: String,
     pub label: String,
+    pub device_type: DeviceType,
     /// Always empty for current advertisers (pairing code is not published on LAN).
     pub code: String,
     pub ticket: String,
@@ -411,6 +433,7 @@ pub fn browse_nearby_receivers(
                     NearbyReceiver {
                         fullname: info.get_fullname().to_owned(),
                         label,
+                        device_type: device_type_from_txt(info.get_properties()),
                         code: String::new(),
                         ticket,
                     },
@@ -470,6 +493,7 @@ mod tests {
 
         let mut m: HashMap<String, String> = HashMap::new();
         m.insert("ver".into(), DRIFT_MDNS_TXT_VER.into());
+        m.insert("dt".into(), "phone".into());
         m.insert("tc".into(), chunks.len().to_string());
         for (i, c) in chunks.iter().enumerate() {
             m.insert(format!("t{i}"), c.clone());
@@ -477,6 +501,13 @@ mod tests {
         let txt = m.into_txt_properties();
         let got = ticket_from_txt(&txt).expect("reassembled");
         assert_eq!(got, ticket);
+        assert_eq!(device_type_from_txt(&txt), DeviceType::Phone);
+    }
+
+    #[test]
+    fn missing_device_type_defaults_to_laptop() {
+        let txt = HashMap::<String, String>::new().into_txt_properties();
+        assert_eq!(device_type_from_txt(&txt), DeviceType::Laptop);
     }
 
     #[test]

--- a/flutter/lib/features/receive/application/state.dart
+++ b/flutter/lib/features/receive/application/state.dart
@@ -52,12 +52,14 @@ class NearbyReceiver {
   const NearbyReceiver({
     required this.fullname,
     required this.label,
+    required this.deviceType,
     required this.code,
     required this.ticket,
   });
 
   final String fullname;
   final String label;
+  final String deviceType;
   final String code;
   final String ticket;
 }

--- a/flutter/lib/features/send/presentation/widgets/send_destination_selector.dart
+++ b/flutter/lib/features/send/presentation/widgets/send_destination_selector.dart
@@ -113,7 +113,7 @@ class _SendDestinationSelectorState
                 return _NearbyDeviceTile(
                   receiver: receiver,
                   isSelected: selected,
-                  icon: Icons.devices_rounded,
+                  icon: _deviceIconForType(receiver.deviceType),
                   onTap: () => widget.controller.selectNearbyReceiver(receiver),
                 );
               },
@@ -246,6 +246,12 @@ class _NearbyStatusCard extends StatelessWidget {
       ),
     );
   }
+}
+
+IconData _deviceIconForType(String deviceType) {
+  return deviceType.toLowerCase() == 'phone'
+      ? Icons.smartphone_rounded
+      : Icons.laptop_mac_rounded;
 }
 
 class _NearbyDeviceTile extends StatelessWidget {

--- a/flutter/lib/platform/rust/receiver/rust_source.dart
+++ b/flutter/lib/platform/rust/receiver/rust_source.dart
@@ -157,6 +157,7 @@ class RustReceiverServiceSource implements ReceiverServiceSource {
           (peer) => NearbyReceiver(
             fullname: peer.fullname,
             label: peer.label,
+            deviceType: peer.deviceType,
             code: peer.code,
             ticket: peer.ticket,
           ),

--- a/flutter/lib/src/rust/api/error.dart
+++ b/flutter/lib/src/rust/api/error.dart
@@ -7,7 +7,7 @@ import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `internal_user_facing_error`, `is_retryable`, `kind`, `map_optional_user_facing_error`, `map_user_facing_error`, `message`, `recovery`, `title`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `from`, `from`, `from`
 
 class UserFacingErrorData implements FrbException {
   final UserFacingErrorKindData kind;

--- a/flutter/lib/src/rust/api/lan.dart
+++ b/flutter/lib/src/rust/api/lan.dart
@@ -19,19 +19,25 @@ Future<List<NearbyReceiverInfo>> scanNearbyReceivers({
 class NearbyReceiverInfo {
   final String fullname;
   final String label;
+  final String deviceType;
   final String code;
   final String ticket;
 
   const NearbyReceiverInfo({
     required this.fullname,
     required this.label,
+    required this.deviceType,
     required this.code,
     required this.ticket,
   });
 
   @override
   int get hashCode =>
-      fullname.hashCode ^ label.hashCode ^ code.hashCode ^ ticket.hashCode;
+      fullname.hashCode ^
+      label.hashCode ^
+      deviceType.hashCode ^
+      code.hashCode ^
+      ticket.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -40,6 +46,7 @@ class NearbyReceiverInfo {
           runtimeType == other.runtimeType &&
           fullname == other.fullname &&
           label == other.label &&
+          deviceType == other.deviceType &&
           code == other.code &&
           ticket == other.ticket;
 }

--- a/flutter/lib/src/rust/api/receiver.dart
+++ b/flutter/lib/src/rust/api/receiver.dart
@@ -10,7 +10,7 @@ import 'transfer.dart';
 
 // These functions are ignored because they are not marked as `pub`: `current_service`, `ensure_receiver_service`, `existing_service_for_config`, `map_event`, `map_file_row`, `map_pairing_state`, `map_phase`, `map_plan_file`, `map_plan`, `map_registration`, `map_snapshot`, `pairing_registration`, `replace_pairing_task`, `replace_updates_task`, `scan_nearby_with_receiver`, `set_discoverable`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BridgeReceiverConfig`, `BridgeReceiverState`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`
 
 Future<ReceiverRegistration> registerReceiver({
   String? serverUrl,

--- a/flutter/lib/src/rust/api/sender.dart
+++ b/flutter/lib/src/rust/api/sender.dart
@@ -8,8 +8,8 @@ import 'error.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'transfer.dart';
 
-// These functions are ignored because they are not marked as `pub`: `fallback_destination_label`, `format_code_label`, `map_event`, `map_phase`, `map_plan_file`, `map_plan`, `map_snapshot`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `cancel_send_session`, `fallback_destination_label`, `format_code_label`, `map_event`, `map_phase`, `map_plan_file`, `map_plan`, `map_snapshot`, `terminal_event_for_app_error`, `terminal_internal_failure_event`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`
 
 Stream<SendTransferEvent> startSendTransfer({
   required SendTransferRequest request,

--- a/flutter/lib/src/rust/frb_generated.dart
+++ b/flutter/lib/src/rust/frb_generated.dart
@@ -867,13 +867,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   NearbyReceiverInfo dco_decode_nearby_receiver_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 4)
-      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return NearbyReceiverInfo(
       fullname: dco_decode_String(arr[0]),
       label: dco_decode_String(arr[1]),
-      code: dco_decode_String(arr[2]),
-      ticket: dco_decode_String(arr[3]),
+      deviceType: dco_decode_String(arr[2]),
+      code: dco_decode_String(arr[3]),
+      ticket: dco_decode_String(arr[4]),
     );
   }
 
@@ -1351,11 +1352,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_fullname = sse_decode_String(deserializer);
     var var_label = sse_decode_String(deserializer);
+    var var_deviceType = sse_decode_String(deserializer);
     var var_code = sse_decode_String(deserializer);
     var var_ticket = sse_decode_String(deserializer);
     return NearbyReceiverInfo(
       fullname: var_fullname,
       label: var_label,
+      deviceType: var_deviceType,
       code: var_code,
       ticket: var_ticket,
     );
@@ -1946,6 +1949,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.fullname, serializer);
     sse_encode_String(self.label, serializer);
+    sse_encode_String(self.deviceType, serializer);
     sse_encode_String(self.code, serializer);
     sse_encode_String(self.ticket, serializer);
   }

--- a/flutter/rust/Cargo.lock
+++ b/flutter/rust/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "drift-app"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "drift-core",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "drift-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bincode",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "drift_bridge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "drift-app",

--- a/flutter/rust/Cargo.toml
+++ b/flutter/rust/Cargo.toml
@@ -3,6 +3,8 @@ name = "drift_bridge"
 version = "0.3.0"
 edition = "2021"
 
+[workspace]
+
 [lib]
 crate-type = ["cdylib", "staticlib"]
 

--- a/flutter/rust/src/api/lan.rs
+++ b/flutter/rust/src/api/lan.rs
@@ -7,6 +7,7 @@ use drift_app::NearbyReceiver;
 pub struct NearbyReceiverInfo {
     pub fullname: String,
     pub label: String,
+    pub device_type: String,
     pub code: String,
     pub ticket: String,
 }
@@ -21,6 +22,7 @@ pub(crate) fn map_nearby_receiver(item: NearbyReceiver) -> NearbyReceiverInfo {
     NearbyReceiverInfo {
         fullname: item.fullname,
         label: item.label,
+        device_type: item.device_type,
         code: item.code,
         ticket: item.ticket,
     }

--- a/flutter/rust/src/frb_generated.rs
+++ b/flutter/rust/src/frb_generated.rs
@@ -811,11 +811,13 @@ impl SseDecode for crate::api::lan::NearbyReceiverInfo {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_fullname = <String>::sse_decode(deserializer);
         let mut var_label = <String>::sse_decode(deserializer);
+        let mut var_deviceType = <String>::sse_decode(deserializer);
         let mut var_code = <String>::sse_decode(deserializer);
         let mut var_ticket = <String>::sse_decode(deserializer);
         return crate::api::lan::NearbyReceiverInfo {
             fullname: var_fullname,
             label: var_label,
+            device_type: var_deviceType,
             code: var_code,
             ticket: var_ticket,
         };
@@ -1334,6 +1336,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::lan::NearbyReceiverInfo {
         [
             self.fullname.into_into_dart().into_dart(),
             self.label.into_into_dart().into_dart(),
+            self.device_type.into_into_dart().into_dart(),
             self.code.into_into_dart().into_dart(),
             self.ticket.into_into_dart().into_dart(),
         ]
@@ -1885,6 +1888,7 @@ impl SseEncode for crate::api::lan::NearbyReceiverInfo {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.fullname, serializer);
         <String>::sse_encode(self.label, serializer);
+        <String>::sse_encode(self.device_type, serializer);
         <String>::sse_encode(self.code, serializer);
         <String>::sse_encode(self.ticket, serializer);
     }

--- a/flutter/test/features/send/application/controller_test.dart
+++ b/flutter/test/features/send/application/controller_test.dart
@@ -215,7 +215,7 @@ void main() {
       controller.selectNearbyReceiver(
         const NearbyReceiver(
           fullname: 'samarth-laptop',
-          label: 'Laptop',
+          label: 'Laptop', deviceType: 'laptop',
           code: 'ABC123',
           ticket: 'ticket-1',
         ),

--- a/flutter/test/features/send/presentation/send_draft_preview_test.dart
+++ b/flutter/test/features/send/presentation/send_draft_preview_test.dart
@@ -297,6 +297,7 @@ void main() {
         NearbyReceiver(
           fullname: 'samarth-laptop',
           label: 'Laptop',
+          deviceType: 'phone',
           code: 'ABC123',
           ticket: 'ticket-1',
         ),
@@ -326,6 +327,8 @@ void main() {
 
     expect(find.text('Nearby devices'), findsOneWidget);
     expect(find.text('Laptop'), findsOneWidget);
+    expect(find.byIcon(Icons.smartphone_rounded), findsOneWidget);
+    expect(find.byIcon(Icons.laptop_mac_rounded), findsNothing);
     expect(find.text('Send with code'), findsOneWidget);
     expect(
       find.text('Use the 6 characters shown on the receiver.'),


### PR DESCRIPTION
This fixes the nearby devices list so it can show the right icon instead of always falling back to a laptop.

The root cause was simple: the nearby scan payload did not preserve device type end to end. I threaded that field through the core LAN discovery path, the app layer, the Flutter bridge, and the send UI. The nearby tile now chooses a phone or laptop icon from the real device type.

Validation:
- flutter test test/features/send/presentation/send_draft_preview_test.dart -r expanded
- cargo test -p drift-core --lib
- cargo test -p drift-app --lib