### PR TITLE
fix: delete transfer workspace after completion

### DIFF
--- a/crates/core/src/transfer/receiver.rs
+++ b/crates/core/src/transfer/receiver.rs
@@ -16,7 +16,7 @@ use tokio::fs;
 use tokio::io::AsyncRead;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::{
     blobs::receive::{BlobDownloadSession, BlobDownloadUpdate, BlobReceiver},
@@ -518,6 +518,7 @@ async fn run_session(
                     session_id: session_id.clone(),
                 },
             );
+            cleanup_transfer_workspace(&record_dir).await;
             Ok(TransferOutcome::Completed)
         }
         Ok(_) => {
@@ -835,13 +836,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::blobs::send::PreparedStore;
     use crate::fs_plan::ConflictPolicy;
     use crate::protocol::message::{
-        BlobTicketMessage, ManifestItem, SenderMessage, TransferAck, TransferManifest, TransferRole,
+        BlobTicketMessage, ManifestItem, SenderMessage, TransferAck, TransferManifest,
     };
     use crate::protocol::wire::{read_sender_message, write_sender_message};
-    use crate::transfer::{SendRequest, Sender};
     use tokio::io::duplex;
 
     fn manifest_with(paths: &[(&str, u64)]) -> OfferManifest {
@@ -959,6 +958,30 @@ mod tests {
 
         let next = read_sender_message(&mut local_read).await.unwrap();
         assert!(matches!(next, SenderMessage::TransferAck(_)));
+    }
+
+    #[tokio::test]
+    async fn cleanup_transfer_workspace_removes_existing_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::write(workspace.join("record.json"), b"{}")
+            .await
+            .unwrap();
+
+        cleanup_transfer_workspace(&workspace).await;
+
+        assert!(!workspace.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_transfer_workspace_ignores_missing_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+
+        cleanup_transfer_workspace(&workspace).await;
+
+        assert!(!workspace.exists());
     }
 }
 
@@ -1088,6 +1111,20 @@ async fn send_receiver_decline(
 async fn finish_control_stream(send: &mut iroh::endpoint::SendStream) {
     let _ = send.finish();
     let _ = tokio::time::timeout(Duration::from_secs(2), send.stopped()).await;
+}
+
+async fn cleanup_transfer_workspace(record_dir: &Path) {
+    match fs::remove_dir_all(record_dir).await {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            warn!(
+                path = %record_dir.display(),
+                error = %err,
+                "failed to clean up transfer workspace"
+            );
+        }
+    }
 }
 
 pub async fn bind_endpoint() -> Result<Endpoint> {


### PR DESCRIPTION
## Summary
- delete the transfer workspace after a successful receive completes and the sender has acknowledged the result
- treat missing workspaces as a no-op and log other cleanup failures without blocking completion
- add tests for existing-directory cleanup and the missing-directory case

## Verification
- cargo test cleanup_transfer_workspace --lib -p drift-core
- cargo test -p drift-core
- cargo test
