### PR TITLE
fix: reject symlinked export parents

### DIFF
--- a/crates/app/src/error.rs
+++ b/crates/app/src/error.rs
@@ -377,7 +377,8 @@ impl From<TransferPathError> for UserFacingError {
             TransferPathError::DestinationExists { .. } => {
                 UserFacingError::from_kind(UserFacingErrorKind::FileConflict)
             }
-            TransferPathError::DestinationParentNotDirectory { .. } => {
+            TransferPathError::DestinationParentIsSymlink { .. }
+            | TransferPathError::DestinationParentNotDirectory { .. } => {
                 UserFacingError::from_kind(UserFacingErrorKind::InvalidInput)
             }
             TransferPathError::CheckPath { source, .. }

--- a/crates/core/src/transfer/error.rs
+++ b/crates/core/src/transfer/error.rs
@@ -79,6 +79,7 @@ impl TransferError {
                 | TransferPathError::InvalidSegment
                 | TransferPathError::InvalidUtf8RootName { .. }
                 | TransferPathError::InvalidUtf8PathComponent { .. }
+                | TransferPathError::DestinationParentIsSymlink { .. }
                 | TransferPathError::DestinationParentNotDirectory { .. }
                 | TransferPathError::CheckPath { .. }
                 | TransferPathError::CurrentDirectory { .. }

--- a/crates/core/src/transfer/path.rs
+++ b/crates/core/src/transfer/path.rs
@@ -21,6 +21,8 @@ pub enum TransferPathError {
     InvalidUtf8PathComponent { path: PathBuf },
     #[error("destination already exists: {path}")]
     DestinationExists { path: PathBuf },
+    #[error("destination parent is a symbolic link: {path}")]
+    DestinationParentIsSymlink { path: PathBuf },
     #[error("destination parent is not a directory: {path}")]
     DestinationParentNotDirectory { path: PathBuf },
     #[error("checking {path}")]
@@ -146,9 +148,15 @@ pub async fn ensure_destination_available(
             break;
         }
 
-        match fs::metadata(parent).await {
+        match fs::symlink_metadata(parent).await {
             Ok(metadata) => {
-                if !metadata.is_dir() {
+                let file_type = metadata.file_type();
+                if file_type.is_symlink() {
+                    return Err(TransferPathError::DestinationParentIsSymlink {
+                        path: parent.to_path_buf(),
+                    });
+                }
+                if !file_type.is_dir() {
                     return Err(TransferPathError::DestinationParentNotDirectory {
                         path: parent.to_path_buf(),
                     });
@@ -247,7 +255,7 @@ impl Drop for ScratchDir {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_output_dir;
+    use super::{TransferPathError, ensure_destination_available, resolve_output_dir};
     use std::path::Path;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -265,6 +273,34 @@ mod tests {
         let cwd = std::env::current_dir()?;
         let resolved = resolve_output_dir(Path::new("./downloads/../downloads/inbox"))?;
         assert_eq!(resolved, cwd.join("downloads/inbox"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ensure_destination_available_rejects_symlinked_parents() -> Result<()> {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir()?;
+        let out_dir = temp.path().join("downloads");
+        let escaped = temp.path().join("escaped");
+        let link = out_dir.join("link");
+        std::fs::create_dir_all(&out_dir)?;
+        std::fs::create_dir_all(&escaped)?;
+        symlink(&escaped, &link)?;
+
+        let destination = link.join("owned.txt");
+        let err = ensure_destination_available(&out_dir, &destination)
+            .await
+            .unwrap_err();
+
+        match err {
+            TransferPathError::DestinationParentIsSymlink { path } => {
+                assert_eq!(path, link);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
         Ok(())
     }
 }

--- a/crates/core/src/transfer/receiver.rs
+++ b/crates/core/src/transfer/receiver.rs
@@ -727,6 +727,7 @@ pub async fn export_downloaded_collection(
                 std::io::Error::other(format!("missing file in collection: {}", exp.path)),
             )
         })?;
+        ensure_destination_available(&record.output_dir, &exp.destination).await?;
         if let Some(p) = exp.destination.parent() {
             fs::create_dir_all(p)
                 .await
@@ -838,10 +839,9 @@ mod tests {
     use crate::blobs::send::PreparedStore;
     use crate::fs_plan::ConflictPolicy;
     use crate::protocol::message::{
-        BlobTicketMessage, ManifestItem, SenderMessage, TransferAck, TransferManifest, TransferRole,
+        BlobTicketMessage, ManifestItem, SenderMessage, TransferAck, TransferManifest,
     };
     use crate::protocol::wire::{read_sender_message, write_sender_message};
-    use crate::transfer::{SendRequest, Sender};
     use tokio::io::duplex;
 
     fn manifest_with(paths: &[(&str, u64)]) -> OfferManifest {
@@ -959,6 +959,55 @@ mod tests {
 
         let next = read_sender_message(&mut local_read).await.unwrap();
         assert!(matches!(next, SenderMessage::TransferAck(_)));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn export_downloaded_collection_rejects_symlinked_parents() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let source_root = temp.path().join("source");
+        let download_root = temp.path().join("downloads");
+        let escape_root = temp.path().join("escape");
+        let record_dir = temp.path().join("record");
+        let source_link = source_root.join("link");
+        let expected_destination = download_root.join("link/owned.txt");
+
+        std::fs::create_dir_all(&source_link).unwrap();
+        std::fs::create_dir_all(&download_root).unwrap();
+        std::fs::create_dir_all(&escape_root).unwrap();
+        std::fs::create_dir_all(&record_dir).unwrap();
+        std::fs::write(source_link.join("owned.txt"), b"owned").unwrap();
+        symlink(&escape_root, download_root.join("link")).unwrap();
+
+        let prepared = PreparedStore::prepare(&source_link, vec![source_link.clone()])
+            .await
+            .unwrap();
+        let mut record = TransferRecord::new(
+            prepared.collection_hash(),
+            download_root.clone(),
+            ConflictPolicy::Rename,
+            prepared.manifest(),
+        );
+        let expected = vec![ExpectedTransferFile {
+            path: "link/owned.txt".to_owned(),
+            size: 5,
+            destination: expected_destination,
+        }];
+
+        let err = export_downloaded_collection(
+            prepared.store(),
+            prepared.collection_hash(),
+            &expected,
+            &mut record,
+            &record_dir,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(format!("{err:#}").contains("symbolic link"));
+        assert!(!escape_root.join("owned.txt").exists());
     }
 }
 


### PR DESCRIPTION
## Summary
- reject symlinked ancestor directories when validating receiver export destinations
- revalidate the destination immediately before exporting so a symlink swap cannot race the planning step
- map the new error to invalid input in the app layer\n- add regression tests for both the path guard and the export-time revalidation

 ## Verification
- cargo test -p drift-core symlinked_parents
- cargo test -p drift-core
- cargo test -p drift-app
- cargo test


Fixes #26 