### PR TITLE
fix: apply receiver conflict policy

### DIFF
--- a/crates/app/src/receiver/actor.rs
+++ b/crates/app/src/receiver/actor.rs
@@ -73,7 +73,15 @@ pub(super) fn spawn_listener_task(
     }
     let device_type = parse_device_type(&device_type)?;
     Ok(tokio::spawn(async move {
-        run_listener_loop(endpoint, cmd_tx, out_dir, device_name, device_type).await;
+        run_listener_loop(
+            endpoint,
+            cmd_tx,
+            out_dir,
+            device_name,
+            device_type,
+            conflict_policy,
+        )
+        .await;
     }))
 }
 
@@ -234,6 +242,7 @@ async fn run_listener_loop(
     out_dir: std::path::PathBuf,
     device_name: String,
     device_type: DeviceType,
+    conflict_policy: ConflictPolicy,
 ) {
     let save_root_label = super::session::save_root_display(&out_dir);
     if let Err(err) = tokio::fs::create_dir_all(&out_dir).await {
@@ -288,6 +297,7 @@ async fn run_listener_loop(
             out_dir_for_offer,
             device_name_for_offer,
             device_type,
+            conflict_policy,
             cmd_tx_for_offer,
         );
         let _ = session.spawn();

--- a/crates/app/src/receiver/session.rs
+++ b/crates/app/src/receiver/session.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 
 use crate::error::{UserFacingError, UserFacingErrorKind, format_error_chain};
-use crate::types::{ReceiverOfferEvent, ReceiverOfferFile, ReceiverOfferPhase};
+use crate::types::{ConflictPolicy, ReceiverOfferEvent, ReceiverOfferFile, ReceiverOfferPhase};
 
 use super::actor::ReceiverCommand;
 use super::runtime::OfferResolution;
@@ -30,6 +30,7 @@ pub(super) struct ReceiverSession {
     out_dir: std::path::PathBuf,
     device_name: String,
     device_type: DeviceType,
+    conflict_policy: ConflictPolicy,
     save_root_label: String,
     cmd_tx: mpsc::Sender<ReceiverCommand>,
 }
@@ -49,6 +50,7 @@ impl ReceiverSession {
         out_dir: std::path::PathBuf,
         device_name: String,
         device_type: DeviceType,
+        conflict_policy: ConflictPolicy,
         cmd_tx: mpsc::Sender<ReceiverCommand>,
     ) -> Self {
         let save_root_label = save_root_display(&out_dir);
@@ -59,6 +61,7 @@ impl ReceiverSession {
             out_dir,
             device_name,
             device_type,
+            conflict_policy,
             save_root_label,
             cmd_tx,
         }
@@ -78,17 +81,19 @@ impl ReceiverSession {
             out_dir,
             device_name,
             device_type,
+            conflict_policy,
             save_root_label,
             cmd_tx,
         } = self;
 
         let connection_path_kind =
             classify_connection_path(&endpoint, connection.remote_id()).await;
-        let session = CoreReceiverSession::new(CoreReceiverRequest {
-            device_name: device_name.clone(),
+        let session = CoreReceiverSession::new(build_core_receiver_request(
+            device_name.clone(),
             device_type,
             out_dir,
-        });
+            conflict_policy,
+        ));
         let start = session.start(endpoint, connection);
         let CoreReceiverStart {
             mut events,
@@ -384,6 +389,20 @@ impl ReceiverSession {
     }
 }
 
+fn build_core_receiver_request(
+    device_name: String,
+    device_type: DeviceType,
+    out_dir: std::path::PathBuf,
+    conflict_policy: ConflictPolicy,
+) -> CoreReceiverRequest {
+    CoreReceiverRequest {
+        device_name,
+        device_type,
+        out_dir,
+        conflict_policy,
+    }
+}
+
 fn completed_offer_event(
     sender_name: String,
     save_root_label: String,
@@ -494,12 +513,26 @@ fn failed_offer_event(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_offer_event, completed_offer_event, connection_path_label, failed_offer_event,
+        build_core_receiver_request, build_offer_event, completed_offer_event,
+        connection_path_label, failed_offer_event,
     };
     use crate::error::UserFacingErrorKind;
+    use crate::types::ConflictPolicy;
     use drift_core::protocol::DeviceType;
     use drift_core::transfer::TransferPlan;
     use drift_core::util::ConnectionPathKind;
+
+    #[test]
+    fn core_receiver_request_preserves_configured_conflict_policy() {
+        let request = build_core_receiver_request(
+            "Receiver".to_owned(),
+            DeviceType::Laptop,
+            std::path::PathBuf::from("downloads"),
+            ConflictPolicy::Reject,
+        );
+
+        assert_eq!(request.conflict_policy, ConflictPolicy::Reject);
+    }
 
     #[test]
     fn failed_offer_event_uses_structured_error() {

--- a/crates/core/src/transfer/receiver.rs
+++ b/crates/core/src/transfer/receiver.rs
@@ -20,6 +20,7 @@ use tracing::{info, instrument, warn};
 
 use crate::{
     blobs::receive::{BlobDownloadSession, BlobDownloadUpdate, BlobReceiver},
+    fs_plan::ConflictPolicy,
     protocol::message as protocol_message,
     protocol::message::MessageKind,
     protocol::wire as protocol_wire,
@@ -45,6 +46,7 @@ pub struct ReceiverRequest {
     pub device_name: String,
     pub device_type: crate::protocol::DeviceType,
     pub out_dir: std::path::PathBuf,
+    pub conflict_policy: ConflictPolicy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -229,20 +231,26 @@ async fn run_session(
         .as_ref()
         .map(|record| resume_offset_for_record(record, plan.total_bytes))
         .unwrap_or(0);
-    let expected_files =
-        match build_expected_files(&manifest, &request.out_dir, resume_record.as_ref()).await {
-            Ok(f) => f,
-            Err(err) => {
-                let reason = err.to_string();
-                let _ = send_receiver_decline(&mut control_send, &session_id, reason.clone()).await;
-                finish_control_stream(&mut control_send).await;
-                let _ = offer_tx.send(Err(TransferError::other(
-                    "building receiver offer",
-                    std::io::Error::other(reason.clone()),
-                )));
-                return Err(err);
-            }
-        };
+    let expected_files = match build_expected_files(
+        &manifest,
+        &request.out_dir,
+        request.conflict_policy,
+        resume_record.as_ref(),
+    )
+    .await
+    {
+        Ok(f) => f,
+        Err(err) => {
+            let reason = err.to_string();
+            let _ = send_receiver_decline(&mut control_send, &session_id, reason.clone()).await;
+            finish_control_stream(&mut control_send).await;
+            let _ = offer_tx.send(Err(TransferError::other(
+                "building receiver offer",
+                std::io::Error::other(reason.clone()),
+            )));
+            return Err(err);
+        }
+    };
 
     let expected_transfer_files = build_expected_transfer_files(&manifest, expected_files)?;
     let receiver_offer = ReceiverOffer {
@@ -315,7 +323,7 @@ async fn run_session(
             let r = TransferRecord::new(
                 receiver_offer.collection_hash,
                 request.out_dir.clone(),
-                crate::fs_plan::ConflictPolicy::Rename, // Default
+                request.conflict_policy,
                 offer.manifest.clone(),
             );
             r.save(&record_dir)
@@ -741,20 +749,14 @@ pub async fn export_downloaded_collection(
 async fn build_expected_files(
     manifest: &OfferManifest,
     out_dir: &Path,
+    conflict_policy: ConflictPolicy,
     resume_record: Option<&TransferRecord>,
 ) -> Result<BTreeMap<String, ExpectedTransferFile>> {
     let mut expected = BTreeMap::new();
     for file in &manifest.files {
-        let destination = resolve_transfer_destination(out_dir, &file.path)?;
-        match ensure_destination_available(out_dir, &destination).await {
-            Ok(()) => {}
-            Err(super::path::TransferPathError::DestinationExists { path })
-                if resume_record
-                    .map(|record| record.exported_files.contains(&file.path))
-                    .unwrap_or(false)
-                    && path == destination => {}
-            Err(error) => return Err(error.into()),
-        }
+        let destination =
+            resolve_expected_destination(out_dir, &file.path, conflict_policy, resume_record)
+                .await?;
         expected.insert(
             file.path.clone(),
             ExpectedTransferFile {
@@ -765,6 +767,43 @@ async fn build_expected_files(
         );
     }
     Ok(expected)
+}
+
+async fn resolve_expected_destination(
+    out_dir: &Path,
+    transfer_path: &str,
+    conflict_policy: ConflictPolicy,
+    resume_record: Option<&TransferRecord>,
+) -> Result<PathBuf> {
+    let destination = resolve_transfer_destination(out_dir, transfer_path)?;
+    match ensure_destination_available(out_dir, &destination).await {
+        Ok(()) => Ok(destination),
+        Err(super::path::TransferPathError::DestinationExists { path })
+            if resume_record
+                .map(|record| record.exported_files.contains(transfer_path))
+                .unwrap_or(false)
+                && path == destination =>
+        {
+            Ok(destination)
+        }
+        Err(super::path::TransferPathError::DestinationExists { .. }) => match conflict_policy {
+            ConflictPolicy::Reject => {
+                Err(super::path::TransferPathError::DestinationExists { path: destination }.into())
+            }
+            ConflictPolicy::Rename => {
+                let resolved = conflict_policy
+                    .resolve(&destination)
+                    .await
+                    .map_err(|error| {
+                        TransferError::other("resolving destination conflict", error)
+                    })?;
+                ensure_destination_available(out_dir, &resolved).await?;
+                Ok(resolved)
+            }
+            ConflictPolicy::Overwrite => Ok(destination),
+        },
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn load_resume_record(
@@ -891,9 +930,10 @@ mod tests {
         let manifest = manifest_with(&[("already.txt", 4), ("remaining.txt", 9)]);
         let record = record_with_exported(&["already.txt"]);
 
-        let expected = build_expected_files(&manifest, out.path(), Some(&record))
-            .await
-            .unwrap();
+        let expected =
+            build_expected_files(&manifest, out.path(), ConflictPolicy::Rename, Some(&record))
+                .await
+                .unwrap();
 
         assert_eq!(
             expected
@@ -906,6 +946,59 @@ mod tests {
                 .get("remaining.txt")
                 .map(|file| file.destination.as_path()),
             Some(out.path().join("remaining.txt").as_path())
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_policy_renames_existing_destinations() {
+        let out = tempfile::tempdir().unwrap();
+        std::fs::write(out.path().join("report.txt"), b"existing").unwrap();
+        let manifest = manifest_with(&[("report.txt", 4)]);
+
+        let expected = build_expected_files(&manifest, out.path(), ConflictPolicy::Rename, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            expected
+                .get("report.txt")
+                .map(|file| file.destination.as_path()),
+            Some(out.path().join("report (1).txt").as_path())
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_policy_keeps_nested_parent_directory() {
+        let out = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(out.path().join("reports")).unwrap();
+        std::fs::write(out.path().join("reports/report.txt"), b"existing").unwrap();
+        let manifest = manifest_with(&[("reports/report.txt", 4)]);
+
+        let expected = build_expected_files(&manifest, out.path(), ConflictPolicy::Rename, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            expected
+                .get("reports/report.txt")
+                .map(|file| file.destination.as_path()),
+            Some(out.path().join("reports/report (1).txt").as_path())
+        );
+    }
+
+    #[tokio::test]
+    async fn reject_policy_fails_existing_destinations() {
+        let out = tempfile::tempdir().unwrap();
+        std::fs::write(out.path().join("report.txt"), b"existing").unwrap();
+        let manifest = manifest_with(&[("report.txt", 4)]);
+
+        let err = build_expected_files(&manifest, out.path(), ConflictPolicy::Reject, None)
+            .await
+            .expect_err("expected reject policy to fail");
+
+        assert!(
+            err.to_string().contains("destination already exists"),
+            "unexpected error: {err:#}"
         );
     }
 


### PR DESCRIPTION
## Summary
- thread receiver conflict policy from app config into core receiver planning
- apply `Reject` and `Rename` when resolving expected destination paths before accept/export
- preserve resume behavior for already-exported files and cover nested rename cases with regression tests

## Root cause
Receiver configuration exposed a conflict policy, but the listener/session/core request path dropped it before normal destination planning. Core then rejected existing destinations directly, so the configured policy never ran.

## Impact
Receiver transfers now honor `Reject` and `Rename` end to end. `Rename` remains the effective default across the existing receive surfaces, and conflicts are resolved before transfer begins.

## Validation
- `cargo fmt`
- `cargo test`

Closes #39.
Closes #27.
