### PR TITLE
[codex] keep Drift listening in the menubar

### DIFF
--- a/flutter/lib/app/app.dart
+++ b/flutter/lib/app/app.dart
@@ -5,7 +5,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../features/receive/application/service.dart';
+import '../features/receive/presentation/receive_transfer_route_gate.dart';
 import 'app_router.dart';
+import '../platform/desktop/desktop_lifecycle.dart';
 import '../theme/drift_theme.dart';
 import '../platform/rust/receiver/source.dart';
 
@@ -24,78 +26,54 @@ class _DriftAppState extends ConsumerState<DriftApp> {
   @override
   void initState() {
     super.initState();
-    _router = buildAppRouter(
-      observers: [DiscoveryRouterObserver(_syncReceiverDiscovery)],
-    );
+    _router = buildAppRouter();
     _receiverService = ref.read(receiverServiceSourceProvider);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        _syncReceiverDiscovery();
+        _setReceiverDiscovery(enabled: true);
       }
     });
   }
 
-  void _syncReceiverDiscovery() {
-    final routePath = _router.routeInformationProvider.value.uri.path;
-    final enabled = routePath == AppRoutePaths.home;
+  void _setReceiverDiscovery({required bool enabled}) {
     if (enabled == _discoverableEnabled) {
       return;
     }
     _discoverableEnabled = enabled;
     debugPrint(
       '[app] receiver discovery ${enabled ? 'enabled' : 'disabled'} '
-      'route="$routePath"',
+      'while app is running',
     );
     unawaited(_receiverService.setDiscoverable(enabled: enabled));
   }
 
+  void _openReceiveTransfer() {
+    unawaited(showDriftWindow());
+    final path = _router.routeInformationProvider.value.uri.path;
+    if (path == AppRoutePaths.receiveTransfer) {
+      return;
+    }
+    unawaited(_router.push(AppRoutePaths.receiveTransfer));
+  }
+
   @override
   void dispose() {
-    unawaited(_receiverService.setDiscoverable(enabled: false));
+    _setReceiverDiscovery(enabled: false);
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'Drift',
-      debugShowCheckedModeBanner: false,
-      theme: buildDriftTheme(),
-      routerConfig: _router,
+    return DesktopLifecycle(
+      child: ReceiveTransferRouteGate(
+        onOpenTransfer: _openReceiveTransfer,
+        child: MaterialApp.router(
+          title: 'Drift',
+          debugShowCheckedModeBanner: false,
+          theme: buildDriftTheme(),
+          routerConfig: _router,
+        ),
+      ),
     );
-  }
-}
-
-class DiscoveryRouterObserver extends NavigatorObserver {
-  DiscoveryRouterObserver(this._sync);
-
-  final VoidCallback _sync;
-
-  void _scheduleSync() {
-    WidgetsBinding.instance.addPostFrameCallback((_) => _sync());
-  }
-
-  @override
-  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didPush(route, previousRoute);
-    _scheduleSync();
-  }
-
-  @override
-  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didPop(route, previousRoute);
-    _scheduleSync();
-  }
-
-  @override
-  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didRemove(route, previousRoute);
-    _scheduleSync();
-  }
-
-  @override
-  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
-    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    _scheduleSync();
   }
 }

--- a/flutter/lib/features/receive/presentation/receive_transfer_route_gate.dart
+++ b/flutter/lib/features/receive/presentation/receive_transfer_route_gate.dart
@@ -6,9 +6,14 @@ import '../../transfers/application/controller.dart';
 import '../../transfers/application/state.dart';
 
 class ReceiveTransferRouteGate extends ConsumerStatefulWidget {
-  const ReceiveTransferRouteGate({super.key, required this.child});
+  const ReceiveTransferRouteGate({
+    super.key,
+    required this.child,
+    this.onOpenTransfer,
+  });
 
   final Widget child;
+  final VoidCallback? onOpenTransfer;
 
   @override
   ConsumerState<ReceiveTransferRouteGate> createState() =>
@@ -36,7 +41,9 @@ class _ReceiveTransferRouteGateState
           _transferRouteActive = false;
           return;
         }
-        context.pushReceiveTransfer();
+        final openTransfer =
+            widget.onOpenTransfer ?? context.pushReceiveTransfer;
+        openTransfer();
       });
     }
 

--- a/flutter/lib/platform/desktop/desktop_lifecycle.dart
+++ b/flutter/lib/platform/desktop/desktop_lifecycle.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tray_manager/tray_manager.dart';
+import 'package:window_manager/window_manager.dart';
+
+import '../../features/receive/application/service.dart';
+
+class DesktopLifecycle extends ConsumerStatefulWidget {
+  const DesktopLifecycle({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<DesktopLifecycle> createState() => _DesktopLifecycleState();
+}
+
+class _DesktopLifecycleState extends ConsumerState<DesktopLifecycle>
+    with WindowListener, TrayListener {
+  static const _showWindowKey = 'show_window';
+  static const _quitKey = 'quit';
+
+  bool _quitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (!_isDesktop) {
+      return;
+    }
+    windowManager.addListener(this);
+    trayManager.addListener(this);
+    unawaited(_initializeDesktopLifecycle());
+  }
+
+  @override
+  void dispose() {
+    if (_isDesktop) {
+      windowManager.removeListener(this);
+      trayManager.removeListener(this);
+    }
+    super.dispose();
+  }
+
+  Future<void> _initializeDesktopLifecycle() async {
+    await windowManager.setPreventClose(true);
+    await trayManager.setIcon(_trayIconPath);
+    await trayManager.setToolTip('Drift is listening for file transfers');
+    await trayManager.setContextMenu(
+      Menu(
+        items: [
+          MenuItem(key: _showWindowKey, label: 'Open Drift'),
+          MenuItem.separator(),
+          MenuItem(key: _quitKey, label: 'Quit Drift'),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void onWindowClose() {
+    unawaited(_hideInsteadOfClosing());
+  }
+
+  @override
+  void onTrayIconMouseDown() {
+    unawaited(showDriftWindow());
+  }
+
+  @override
+  void onTrayIconRightMouseDown() {
+    unawaited(trayManager.popUpContextMenu());
+  }
+
+  @override
+  void onTrayMenuItemClick(MenuItem menuItem) {
+    switch (menuItem.key) {
+      case _showWindowKey:
+        unawaited(showDriftWindow());
+        break;
+      case _quitKey:
+        unawaited(_quitApp());
+        break;
+    }
+  }
+
+  Future<void> _hideInsteadOfClosing() async {
+    if (_quitting) {
+      return;
+    }
+    if (await windowManager.isPreventClose()) {
+      await windowManager.hide();
+    }
+  }
+
+  Future<void> _quitApp() async {
+    _quitting = true;
+    await ref.read(receiverServiceSourceProvider).shutdown();
+    await trayManager.destroy();
+    await windowManager.setPreventClose(false);
+    await windowManager.destroy();
+    exit(0);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+Future<void> showDriftWindow() async {
+  if (!_isDesktop) {
+    return;
+  }
+  await windowManager.show();
+  await windowManager.restore();
+  await windowManager.focus();
+}
+
+bool get _isDesktop =>
+    Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+
+String get _trayIconPath {
+  if (Platform.isWindows) {
+    return 'windows/runner/resources/app_icon.ico';
+  }
+  return 'assets/logo.png';
+}

--- a/flutter/lib/shell/desktop_shell.dart
+++ b/flutter/lib/shell/desktop_shell.dart
@@ -6,7 +6,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/receive/application/controller.dart';
 import '../features/receive/presentation/widgets/idle_card.dart';
-import '../features/receive/presentation/receive_transfer_route_gate.dart';
 import '../app/app_router.dart';
 import '../features/send/application/model.dart';
 import '../features/send/application/send_selection_picker.dart';
@@ -78,46 +77,44 @@ class DesktopShell extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final receiverState = ref.watch(receiverIdleViewStateProvider);
-    return ReceiveTransferRouteGate(
-      child: Scaffold(
-        backgroundColor: kBg,
-        body: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              ReceiveIdleCard(
-                state: receiverState,
-                onOpenSettings: () {
-                  context.goSettings();
+    return Scaffold(
+      backgroundColor: kBg,
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            ReceiveIdleCard(
+              state: receiverState,
+              onOpenSettings: () {
+                context.goSettings();
+              },
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: SendDropZone(
+                onChooseFiles: () {
+                  return showSendSelectionSourceSheet(
+                    context,
+                    onChooseFiles: () => _pickFiles(context, ref),
+                    onChooseFolder: () => _pickFolder(context, ref),
+                  );
+                },
+                onDropPaths: (paths) {
+                  if (paths.isEmpty) {
+                    return;
+                  }
+                  unawaited(
+                    _loadDroppedFiles(paths).then((files) async {
+                      if (!context.mounted) {
+                        return;
+                      }
+                      await _openSelectedFiles(context, files);
+                    }),
+                  );
                 },
               ),
-              const SizedBox(height: 12),
-              Expanded(
-                child: SendDropZone(
-                  onChooseFiles: () {
-                    return showSendSelectionSourceSheet(
-                      context,
-                      onChooseFiles: () => _pickFiles(context, ref),
-                      onChooseFolder: () => _pickFolder(context, ref),
-                    );
-                  },
-                  onDropPaths: (paths) {
-                    if (paths.isEmpty) {
-                      return;
-                    }
-                    unawaited(
-                      _loadDroppedFiles(paths).then((files) async {
-                        if (!context.mounted) {
-                          return;
-                        }
-                        await _openSelectedFiles(context, files);
-                      }),
-                    );
-                  },
-                ),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/flutter/lib/shell/mobile_shell.dart
+++ b/flutter/lib/shell/mobile_shell.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/receive/application/controller.dart';
-import '../features/receive/presentation/receive_transfer_route_gate.dart';
 import '../features/send/presentation/send_selection_source_sheet.dart';
 import '../app/app_router.dart';
 import '../theme/drift_theme.dart';
@@ -17,52 +16,50 @@ class MobileShell extends ConsumerWidget with ShellPickingActions {
   Widget build(BuildContext context, WidgetRef ref) {
     final receiverState = ref.watch(receiverIdleViewStateProvider);
 
-    return ReceiveTransferRouteGate(
-      child: Scaffold(
-        backgroundColor: kBg,
-        body: CustomScrollView(
-          physics: const BouncingScrollPhysics(),
-          slivers: [
-            SliverToBoxAdapter(
-              child: SafeArea(
-                bottom: false,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
-                  child: Row(
-                    children: [
-                      const Spacer(),
-                      IconButton(
-                        onPressed: () => context.goSettings(),
-                        icon: const Icon(Icons.tune_rounded),
-                        tooltip: 'Settings',
-                      ),
-                    ],
-                  ),
+    return Scaffold(
+      backgroundColor: kBg,
+      body: CustomScrollView(
+        physics: const BouncingScrollPhysics(),
+        slivers: [
+          SliverToBoxAdapter(
+            child: SafeArea(
+              bottom: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                child: Row(
+                  children: [
+                    const Spacer(),
+                    IconButton(
+                      onPressed: () => context.goSettings(),
+                      icon: const Icon(Icons.tune_rounded),
+                      tooltip: 'Settings',
+                    ),
+                  ],
                 ),
               ),
             ),
-            SliverPadding(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              sliver: SliverList(
-                delegate: SliverChildListDelegate([
-                  const SizedBox(height: 8),
-                  MobileIdentityCard(state: receiverState),
-                  const SizedBox(height: 32),
-                  SelectFilesCard(
-                    onTap: () {
-                      showSendSelectionSourceSheet(
-                        context,
-                        onChooseFiles: () => pickFiles(context, ref),
-                        onChooseFolder: () => pickFolder(context, ref),
-                      );
-                    },
-                  ),
-                  const SizedBox(height: 24),
-                ]),
-              ),
+          ),
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            sliver: SliverList(
+              delegate: SliverChildListDelegate([
+                const SizedBox(height: 8),
+                MobileIdentityCard(state: receiverState),
+                const SizedBox(height: 32),
+                SelectFilesCard(
+                  onTap: () {
+                    showSendSelectionSourceSheet(
+                      context,
+                      onChooseFiles: () => pickFiles(context, ref),
+                      onChooseFolder: () => pickFolder(context, ref),
+                    );
+                  },
+                ),
+                const SizedBox(height: 24),
+              ]),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/flutter/linux/flutter/generated_plugin_registrant.cc
+++ b/flutter/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <tray_manager/tray_manager_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -21,6 +22,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) tray_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "TrayManagerPlugin");
+  tray_manager_plugin_register_with_registrar(tray_manager_registrar);
   g_autoptr(FlPluginRegistrar) window_manager_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
   window_manager_plugin_register_with_registrar(window_manager_registrar);

--- a/flutter/linux/flutter/generated_plugins.cmake
+++ b/flutter/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_linux
   screen_retriever_linux
+  tray_manager
   window_manager
 )
 

--- a/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import desktop_drop
 import file_selector_macos
 import screen_retriever_macos
 import shared_preferences_foundation
+import tray_manager
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -16,5 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/flutter/macos/Podfile.lock
+++ b/flutter/macos/Podfile.lock
@@ -11,6 +11,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - tray_manager (0.0.1):
+    - FlutterMacOS
   - window_manager (0.5.0):
     - FlutterMacOS
 
@@ -21,6 +23,7 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - tray_manager (from `Flutter/ephemeral/.symlinks/plugins/tray_manager/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
@@ -36,6 +39,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  tray_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/tray_manager/macos
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
@@ -46,6 +51,7 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  tray_manager: a104b5c81b578d83f3c3d0f40a997c8b10810166
   window_manager: b729e31d38fb04905235df9ea896128991cad99e
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009

--- a/flutter/macos/Runner/AppDelegate.swift
+++ b/flutter/macos/Runner/AppDelegate.swift
@@ -4,7 +4,7 @@ import FlutterMacOS
 @main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-    return true
+    return false
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -598,6 +598,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  menu_base:
+    dependency: transitive
+    description:
+      name: menu_base
+      sha256: "820368014a171bd1241030278e6c2617354f492f5c703d7b7d4570a6b8b84405"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   meta:
     dependency: transitive
     description:
@@ -958,6 +966,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  shortid:
+    dependency: transitive
+    description:
+      name: shortid
+      sha256: d0b40e3dbb50497dad107e19c54ca7de0d1a274eb9b4404991e443dadb9ebedb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1075,6 +1091,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  tray_manager:
+    dependency: "direct main"
+    description:
+      name: tray_manager
+      sha256: c5fd83b0ae4d80be6eaedfad87aaefab8787b333b8ebd064b0e442a81006035b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
   typed_data:
     dependency: transitive
     description:

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   window_manager: ^0.5.1
   drift_bridge:
     path: rust_builder
+  tray_manager: ^0.5.2
 
 dev_dependencies:
   flutter_test:
@@ -82,6 +83,9 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  assets:
+    - assets/logo.png
+    - windows/runner/resources/app_icon.ico
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/flutter/test/app_router_test.dart
+++ b/flutter/test/app_router_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:app/app/app.dart';
 import 'package:app/app/app_router.dart';
 import 'package:app/features/receive/application/service.dart';
@@ -7,8 +5,8 @@ import 'package:app/features/send/application/model.dart';
 import 'package:app/features/send/application/send_selection_picker.dart';
 import 'package:app/platform/rust/receiver/fake_source.dart';
 import 'package:app/features/settings/settings_providers.dart';
-import 'package:app/features/send/presentation/send_draft_preview.dart';
 import 'package:app/features/send/presentation/send_transfer_route.dart';
+import 'package:app/features/transfers/feature.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -127,7 +125,7 @@ void main() {
     expect(receiverSource.setDiscoverableCalls, 1);
   });
 
-  testWidgets('receiver discovery turns off for settings and back on home', (
+  testWidgets('receiver discovery stays on while navigating settings', (
     tester,
   ) async {
     final receiverSource = FakeReceiverServiceSource();
@@ -148,58 +146,43 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Settings'), findsWidgets);
-    expect(receiverSource.lastDiscoverableEnabled, isFalse);
+    expect(receiverSource.lastDiscoverableEnabled, isTrue);
+    expect(receiverSource.setDiscoverableCalls, 1);
 
     await tester.tap(find.byTooltip('Back'));
     await tester.pumpAndSettle();
 
     expect(find.text('Drop files to send'), findsOneWidget);
     expect(receiverSource.lastDiscoverableEnabled, isTrue);
+    expect(receiverSource.setDiscoverableCalls, 1);
   });
 
-  testWidgets('receiver discovery turns off while send draft is open', (
+  testWidgets('incoming offers open the receive UI from settings', (
     tester,
   ) async {
     final receiverSource = FakeReceiverServiceSource();
-    late final GoRouter router;
-    final discoveryObserver = DiscoveryRouterObserver(() {
-      final uri = router.routeInformationProvider.value.uri;
-      final enabled = uri.path == AppRoutePaths.home;
-      unawaited(receiverSource.setDiscoverable(enabled: enabled));
-    });
-    router = buildAppRouter(observers: [discoveryObserver]);
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          transferReviewAnimationProvider.overrideWithValue(false),
           initialAppSettingsProvider.overrideWithValue(testAppSettings),
           receiverServiceSourceProvider.overrideWithValue(receiverSource),
+          transfersServiceSourceProvider.overrideWithValue(receiverSource),
         ],
-        child: MaterialApp.router(routerConfig: router),
+        child: const DriftApp(),
       ),
     );
     await tester.pumpAndSettle();
 
-    expect(receiverSource.lastDiscoverableEnabled, isTrue);
-
-    router.go(
-      AppRoutePaths.sendDraft,
-      extra: [
-        SendPickedFile(
-          path: '/tmp/report.pdf',
-          name: 'report.pdf',
-          sizeBytes: BigInt.from(1024),
-        ),
-      ],
-    );
+    await tester.tap(find.byTooltip('Settings'));
     await tester.pumpAndSettle();
 
-    expect(find.byType(SendDraftPreview), findsOneWidget);
-    expect(receiverSource.lastDiscoverableEnabled, isFalse);
+    expect(find.text('Settings'), findsWidgets);
 
-    await tester.tap(find.byTooltip('Back'));
+    receiverSource.emitIncomingOffer(senderName: 'Maya');
     await tester.pumpAndSettle();
 
-    expect(find.text('Drop files to send'), findsOneWidget);
-    expect(receiverSource.lastDiscoverableEnabled, isTrue);
+    expect(find.text('INCOMING'), findsOneWidget);
+    expect(find.text('Maya'), findsAtLeastNWidgets(1));
   });
 }

--- a/flutter/windows/flutter/generated_plugin_registrant.cc
+++ b/flutter/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <desktop_drop/desktop_drop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <tray_manager/tray_manager_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -18,6 +19,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  TrayManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("TrayManagerPlugin"));
   WindowManagerPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/flutter/windows/flutter/generated_plugins.cmake
+++ b/flutter/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   desktop_drop
   file_selector_windows
   screen_retriever_windows
+  tray_manager
   window_manager
 )
 

--- a/flutter/windows/runner/main.cpp
+++ b/flutter/windows/runner/main.cpp
@@ -30,7 +30,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   if (!window.Create(L"Drift", origin, size)) {
     return EXIT_FAILURE;
   }
-  window.SetQuitOnClose(true);
+  window.SetQuitOnClose(false);
 
   ::MSG msg;
   while (::GetMessage(&msg, nullptr, 0, 0)) {


### PR DESCRIPTION
## What changed
- Added a desktop tray/menubar lifecycle layer so Drift can hide instead of quitting on close.
- Kept receiver discovery enabled while the app is running, so the listener stays active even when the window is not on the home route.
- Made incoming offers restore/focus the app and open the existing receive-transfer UI.
- Added a focused test covering offers that arrive while the app is on Settings.

## Why
The goal is to let Drift keep listening for file transfers from the menubar without building a larger background-mode/settings workflow yet.

## Validation
- `flutter test test/app_router_test.dart`
- `flutter test test/features/receive/feature_test.dart test/features/transfers/service_test.dart`
- `flutter analyze`
- `flutter build macos --debug`

## Notes
- The PR intentionally stays minimal: it keeps listening and surfaces incoming offers in the UI, but does not add a dedicated background-listening toggle yet.