### PR TITLE
fix: out of memory when open large file on android

### DIFF
--- a/flutter/android/app/src/main/kotlin/com/example/drift/MainActivity.kt
+++ b/flutter/android/app/src/main/kotlin/com/example/drift/MainActivity.kt
@@ -1,5 +1,113 @@
 package com.example.drift
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.io.FileOutputStream
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+
+    companion object {
+        private const val CHANNEL = "com.example.drift/file_picker"
+        private const val REQUEST_CODE_PICK_FILES = 2001
+    }
+
+    private var pendingResult: MethodChannel.Result? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            CHANNEL,
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "pickFiles" -> {
+                    if (pendingResult != null) {
+                        result.error("ALREADY_PICKING", "A file pick is already in progress", null)
+                        return@setMethodCallHandler
+                    }
+                    pendingResult = result
+                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        type = "*/*"
+                        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                    }
+                    @Suppress("DEPRECATION")
+                    startActivityForResult(intent, REQUEST_CODE_PICK_FILES)
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == REQUEST_CODE_PICK_FILES) {
+            val result = pendingResult
+            pendingResult = null
+            if (result == null) {
+                super.onActivityResult(requestCode, resultCode, data)
+                return
+            }
+            if (resultCode != Activity.RESULT_OK || data == null) {
+                result.success(emptyList<String>())
+                return
+            }
+            val uris = mutableListOf<Uri>()
+            val clipData = data.clipData
+            if (clipData != null) {
+                for (i in 0 until clipData.itemCount) {
+                    uris.add(clipData.getItemAt(i).uri)
+                }
+            } else {
+                data.data?.let { uris.add(it) }
+            }
+            val paths = uris.mapNotNull { uri -> copyUriToCache(uri) }
+            result.success(paths)
+            return
+        }
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    // Streams a content URI to the app cache directory to avoid encoding
+    // large files as bytes through the Flutter platform channel.
+    private fun copyUriToCache(uri: Uri): String? {
+        return try {
+            val fileName = resolveFileName(uri) ?: "picked_${System.currentTimeMillis()}"
+            val dir = File(cacheDir, "drift_picked")
+            dir.mkdirs()
+            // Prefix with timestamp so repeated picks of the same name don't collide.
+            val cacheFile = File(dir, "${System.currentTimeMillis()}_$fileName")
+            contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(cacheFile).use { output ->
+                    input.copyTo(output, bufferSize = 65_536)
+                }
+            }
+            cacheFile.absolutePath
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun resolveFileName(uri: Uri): String? {
+        return try {
+            contentResolver.query(
+                uri,
+                arrayOf(OpenableColumns.DISPLAY_NAME),
+                null, null, null,
+            )?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0) cursor.getString(idx) else null
+                } else null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/flutter/lib/features/send/application/send_selection_picker.dart
+++ b/flutter/lib/features/send/application/send_selection_picker.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../platform/android_file_picker.dart';
 import 'model.dart';
 
 abstract class SendSelectionPicker {
@@ -16,6 +19,30 @@ final sendSelectionPickerProvider = Provider<SendSelectionPicker>((_) {
 class FileSelectorSendSelectionPicker implements SendSelectionPicker {
   @override
   Future<List<SendPickedFile>> pickFiles() async {
+    // On Android, file_selector_android <= 0.5.2+x reads the entire file into
+    // a ByteArrayOutputStream and sends it through the platform channel.
+    // For large files this triggers an OutOfMemoryError.  Use a custom
+    // MethodChannel that copies files to the app cache via streaming instead.
+    if (Platform.isAndroid) {
+      final paths = await AndroidFilePicker.pickFiles();
+      return paths
+          .map((path) {
+            BigInt? sizeBytes;
+            try {
+              sizeBytes = BigInt.from(File(path).lengthSync());
+            } catch (_) {
+              sizeBytes = null;
+            }
+            return SendPickedFile(
+              path: path,
+              name: SendPickedFile.fromPath(path).name,
+              kind: SendPickedFileKind.file,
+              sizeBytes: sizeBytes,
+            );
+          })
+          .toList(growable: false);
+    }
+
     final pickedFiles = await openFiles();
     return Future.wait(
       pickedFiles.map((file) async {

--- a/flutter/lib/platform/android_file_picker.dart
+++ b/flutter/lib/platform/android_file_picker.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/services.dart';
+
+/// Calls a native Android [MethodChannel] that streams picked files to the
+/// app cache directory and returns file-system paths.  This avoids the
+/// [file_selector_android] bug (versions <= 0.5.2+x) where the entire file
+/// is read into a [Uint8List] and encoded through the platform channel,
+/// causing [OutOfMemoryError] for large files.
+class AndroidFilePicker {
+  static const MethodChannel _channel = MethodChannel(
+    'com.example.drift/file_picker',
+  );
+
+  /// Opens the system file picker and returns a list of absolute paths to
+  /// copies of the selected files stored in the app cache directory.
+  static Future<List<String>> pickFiles() async {
+    final result = await _channel.invokeMethod<List<dynamic>>('pickFiles');
+    return result?.cast<String>() ?? const [];
+  }
+}


### PR DESCRIPTION
> The PR content was generated by AI.

## fix: work around file_selector_android OOM on large file picks

### Problem

Picking a large file (≥ ~195 MB) on Android crashes with:

```
java.lang.OutOfMemoryError: Failed to allocate a 205235072 byte allocation
  at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
  at io.flutter.plugin.common.StandardMessageCodec.writeValue(...)
  at dev.flutter.packages.file_selector_android.GeneratedFileSelectorApi$PigeonCodec.writeValue(...)
```

**Root cause:** `file_selector_android ≤ 0.5.2+6` reads the **entire picked file into a `ByteArrayOutputStream`** on the Java side and encodes it as a raw byte array through Flutter's `StandardMessageCodec` platform channel. For files larger than a few hundred MB this exhausts Android's heap before any Dart code runs.

An upstream fix has been proposed ([flutter/flutter#141002](https://github.com/flutter/flutter/issues/141002#issuecomment-2898634234)) that would change the Java side to skip the byte read when a cache path is already available, and change the Dart side to prefer `XFile(path)` over `XFile.fromData(bytes)`. However, the proposed Dart-only snippet is insufficient on its own — the OOM occurs on the Java side before the channel message is delivered to Dart, so both halves must ship together. No fixed release is available yet.

### Solution

Bypass `file_selector_android` for `pickFiles` on Android using a direct `MethodChannel` implementation inside the app that never puts file bytes on the platform channel.

**Flow:**
1. `MainActivity` registers a `MethodChannel` (`com.example.drift/file_picker`)
2. On `pickFiles`, opens `Intent.ACTION_OPEN_DOCUMENT` (system file picker, multi-select)
3. In `onActivityResult`, streams each content URI to `cacheDir/drift_picked/` in 64 KB chunks via `InputStream.copyTo()` — no large heap allocation
4. Returns only the resulting file-system paths to Dart
5. On the Dart side, `SendSelectionPicker.pickFiles()` detects `Platform.isAndroid` and delegates to `AndroidFilePicker`; all other platforms continue using `file_selector` unchanged

### Files changed

| File | Change |
|---|---|
| `android/app/src/main/kotlin/…/MainActivity.kt` | Added `MethodChannel` handler with `Intent.ACTION_OPEN_DOCUMENT`, streaming copy to cache, filename resolution via `OpenableColumns` |
| `lib/platform/android_file_picker.dart` | New Dart wrapper calling the channel |
| `lib/features/send/application/send_selection_picker.dart` | Android branch delegates to `AndroidFilePicker`; non-Android path unchanged |

### Future cleanup

Once a fully patched `file_selector_android` (both Java and Dart sides) is published, the `Platform.isAndroid` branch in send_selection_picker.dart, android_file_picker.dart, and the `MainActivity` channel can all be removed and the code reverted to using `openFiles()` directly.